### PR TITLE
fix: Add reflection auto-detection to REST API entry endpoint

### DIFF
--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -4100,12 +4100,16 @@ const server = createServer(async (req, res) => {
       const user = await storage.getUserByKeyHash(keyHash);
       const handle = user?.handle || undefined;
 
+      // Auto-detect reflections by content length (500+ chars = essay/reflection)
+      const isReflection = content.trim().length >= 500;
+
       const entryData: Omit<JournalEntry, 'id'> = {
         pseudonym,
         handle,
         client: 'desktop', // Default for REST API
         content: content.trim(),
         timestamp: Date.now(),
+        isReflection: isReflection || undefined,
       };
 
       if (parentEntry) {


### PR DESCRIPTION
## Summary
- The MCP tool handler (`write_to_shared_notebook`) auto-detects reflections by checking content length >= 500 chars and sets `isReflection: true`
- The REST API `POST /api/entries` endpoint did **not** do this
- Entries created via REST API rendered as plain escaped text instead of markdown on the frontend

## Changes
- **server/src/http.ts**: Added 2 lines to `POST /api/entries` handler — identical reflection auto-detection logic already used by the MCP tool handler (line 1549-1550)

## Testing
- All 247 existing tests pass
- Parity fix — matches existing behavior in the MCP handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)