### PR TITLE
Convert sidebar layout to sticky top bar with centered feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ Thumbs.db
 # Logs
 *.log
 npm-debug.log*
+
+# Scratch
+scratch/

--- a/connect.html
+++ b/connect.html
@@ -15,25 +15,38 @@
         }
 
         :root {
-            --bg: #faf9f7;
-            --surface: #ffffff;
-            --border: #e8e6e3;
-            --fg: #1a1a1a;
-            --fg-muted: #6b6b6b;
+            --bg: #e8e4db;
+            --surface: #f4f2ec;
+            --surface-raised: #fdfcf9;
+            --border: #c9c3b8;
+            --border-subtle: #dbd6cc;
+            --fg: #1c1917;
+            --fg-muted: #57534e;
+            --fg-faint: #78716c;
             --accent: #7c5cbf;
-            --accent-soft: rgba(124, 92, 191, 0.1);
-            --success: #81c784;
+            --accent-hover: #6b4dab;
+            --accent-subtle: rgba(124, 92, 191, 0.08);
+            --accent-surface: rgba(124, 92, 191, 0.04);
+            --success: #16a34a;
+            --warning: #d97706;
         }
 
         @media (prefers-color-scheme: dark) {
             :root {
-                --bg: #0a0a0b;
-                --surface: #111113;
-                --border: #2a2a2e;
-                --fg: #e4e4e7;
-                --fg-muted: #8b8b8b;
+                --bg: #0e0d0b;
+                --surface: #161513;
+                --surface-raised: #1e1d1a;
+                --border: #2e2c28;
+                --border-subtle: #232220;
+                --fg: #e7e5e0;
+                --fg-muted: #a8a49d;
+                --fg-faint: #6b6860;
                 --accent: #a78bfa;
-                --accent-soft: rgba(167, 139, 250, 0.1);
+                --accent-hover: #b9a0fc;
+                --accent-subtle: rgba(167, 139, 250, 0.1);
+                --accent-surface: rgba(167, 139, 250, 0.04);
+                --success: #4ade80;
+                --warning: #fbbf24;
             }
         }
 
@@ -43,6 +56,7 @@
             color: var(--fg);
             min-height: 100vh;
             padding: 2rem;
+            -webkit-font-smoothing: antialiased;
         }
 
         .container {
@@ -94,7 +108,7 @@
 
         /* Key banner */
         .key-banner {
-            background: var(--accent-soft);
+            background: var(--accent-subtle);
             border: 1px solid var(--accent);
             border-radius: 8px;
             padding: 1rem 1.25rem;
@@ -106,8 +120,8 @@
         }
 
         .key-banner.no-key {
-            background: rgba(255, 183, 77, 0.1);
-            border-color: #ffb74d;
+            background: color-mix(in srgb, var(--warning) 10%, transparent);
+            border-color: var(--warning);
         }
 
         .key-banner .label {
@@ -324,7 +338,7 @@
 
         /* Note */
         .note {
-            background: var(--accent-soft);
+            background: var(--accent-subtle);
             border: 1px solid rgba(167, 139, 250, 0.2);
             border-radius: 8px;
             padding: 1rem 1.25rem;

--- a/connect.html
+++ b/connect.html
@@ -31,8 +31,25 @@
             --warning: #d97706;
         }
 
+        :root[data-theme="dark"] {
+            --bg: #0e0d0b;
+            --surface: #161513;
+            --surface-raised: #1e1d1a;
+            --border: #2e2c28;
+            --border-subtle: #232220;
+            --fg: #e7e5e0;
+            --fg-muted: #a8a49d;
+            --fg-faint: #6b6860;
+            --accent: #a78bfa;
+            --accent-hover: #b9a0fc;
+            --accent-subtle: rgba(167, 139, 250, 0.1);
+            --accent-surface: rgba(167, 139, 250, 0.04);
+            --success: #4ade80;
+            --warning: #fbbf24;
+        }
+
         @media (prefers-color-scheme: dark) {
-            :root {
+            :root:not([data-theme]) {
                 --bg: #0e0d0b;
                 --surface: #161513;
                 --surface-raised: #1e1d1a;
@@ -378,6 +395,13 @@
             opacity: 1;
         }
     </style>
+    <script>
+        // Apply saved theme before paint to prevent flash
+        (function() {
+            const saved = document.cookie.match(/(?:^|; )hermes_theme=(\w+)/);
+            if (saved) document.documentElement.setAttribute('data-theme', saved[1]);
+        })();
+    </script>
 </head>
 <body>
     <div class="container">

--- a/dashboard.html
+++ b/dashboard.html
@@ -15,12 +15,19 @@
         }
 
         :root {
-            --bg: #faf9f7;
-            --surface: #ffffff;
-            --border: #e8e6e3;
-            --fg: #1a1a1a;
-            --fg-muted: #6b6b6b;
+            --bg: #e8e4db;
+            --surface: #f4f2ec;
+            --surface-raised: #fdfcf9;
+            --border: #c9c3b8;
+            --border-subtle: #dbd6cc;
+            --fg: #1c1917;
+            --fg-muted: #57534e;
+            --fg-faint: #78716c;
             --accent: #7c5cbf;
+            --accent-hover: #6b4dab;
+            --accent-subtle: rgba(124, 92, 191, 0.08);
+            --accent-surface: rgba(124, 92, 191, 0.04);
+            --color-error: #dc2626;
         }
 
         body {
@@ -29,6 +36,7 @@
             color: var(--fg);
             min-height: 100vh;
             padding: 2rem;
+            -webkit-font-smoothing: antialiased;
         }
 
         .container {
@@ -256,7 +264,7 @@
 
         .error {
             text-align: center;
-            color: #c53030;
+            color: var(--color-error);
             padding: 2rem;
         }
 
@@ -271,6 +279,23 @@
 
             .stat-value {
                 font-size: 1.5rem;
+            }
+        }
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #0e0d0b;
+                --surface: #161513;
+                --surface-raised: #1e1d1a;
+                --border: #2e2c28;
+                --border-subtle: #232220;
+                --fg: #e7e5e0;
+                --fg-muted: #a8a49d;
+                --fg-faint: #6b6860;
+                --accent: #a78bfa;
+                --accent-hover: #b9a0fc;
+                --accent-subtle: rgba(167, 139, 250, 0.1);
+                --accent-surface: rgba(167, 139, 250, 0.04);
+                --color-error: #f87171;
             }
         }
     </style>

--- a/dashboard.html
+++ b/dashboard.html
@@ -281,8 +281,24 @@
                 font-size: 1.5rem;
             }
         }
+        :root[data-theme="dark"] {
+            --bg: #0e0d0b;
+            --surface: #161513;
+            --surface-raised: #1e1d1a;
+            --border: #2e2c28;
+            --border-subtle: #232220;
+            --fg: #e7e5e0;
+            --fg-muted: #a8a49d;
+            --fg-faint: #6b6860;
+            --accent: #a78bfa;
+            --accent-hover: #b9a0fc;
+            --accent-subtle: rgba(167, 139, 250, 0.1);
+            --accent-surface: rgba(167, 139, 250, 0.04);
+            --color-error: #f87171;
+        }
+
         @media (prefers-color-scheme: dark) {
-            :root {
+            :root:not([data-theme]) {
                 --bg: #0e0d0b;
                 --surface: #161513;
                 --surface-raised: #1e1d1a;
@@ -299,6 +315,13 @@
             }
         }
     </style>
+    <script>
+        // Apply saved theme before paint to prevent flash
+        (function() {
+            const saved = document.cookie.match(/(?:^|; )hermes_theme=(\w+)/);
+            if (saved) document.documentElement.setAttribute('data-theme', saved[1]);
+        })();
+    </script>
 </head>
 <body>
     <div class="container">

--- a/entry.html
+++ b/entry.html
@@ -31,8 +31,24 @@
             --color-error: #dc2626;
         }
 
+        :root[data-theme="dark"] {
+            --bg: #0e0d0b;
+            --surface: #161513;
+            --surface-raised: #1e1d1a;
+            --border: #2e2c28;
+            --border-subtle: #232220;
+            --fg: #e7e5e0;
+            --fg-muted: #a8a49d;
+            --fg-faint: #6b6860;
+            --accent: #a78bfa;
+            --accent-hover: #b9a0fc;
+            --accent-subtle: rgba(167, 139, 250, 0.1);
+            --accent-surface: rgba(167, 139, 250, 0.04);
+            --color-error: #f87171;
+        }
+
         @media (prefers-color-scheme: dark) {
-            :root {
+            :root:not([data-theme]) {
                 --bg: #0e0d0b;
                 --surface: #161513;
                 --surface-raised: #1e1d1a;
@@ -319,6 +335,13 @@
             }
         }
     </style>
+    <script>
+        // Apply saved theme before paint to prevent flash
+        (function() {
+            const saved = document.cookie.match(/(?:^|; )hermes_theme=(\w+)/);
+            if (saved) document.documentElement.setAttribute('data-theme', saved[1]);
+        })();
+    </script>
 </head>
 <body>
     <div class="container">

--- a/entry.html
+++ b/entry.html
@@ -16,12 +16,37 @@
         }
 
         :root {
-            --bg: #faf9f7;
-            --surface: #ffffff;
-            --border: #e8e6e3;
-            --fg: #1a1a1a;
-            --fg-muted: #6b6b6b;
+            --bg: #e8e4db;
+            --surface: #f4f2ec;
+            --surface-raised: #fdfcf9;
+            --border: #c9c3b8;
+            --border-subtle: #dbd6cc;
+            --fg: #1c1917;
+            --fg-muted: #57534e;
+            --fg-faint: #78716c;
             --accent: #7c5cbf;
+            --accent-hover: #6b4dab;
+            --accent-subtle: rgba(124, 92, 191, 0.08);
+            --accent-surface: rgba(124, 92, 191, 0.04);
+            --color-error: #dc2626;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #0e0d0b;
+                --surface: #161513;
+                --surface-raised: #1e1d1a;
+                --border: #2e2c28;
+                --border-subtle: #232220;
+                --fg: #e7e5e0;
+                --fg-muted: #a8a49d;
+                --fg-faint: #6b6860;
+                --accent: #a78bfa;
+                --accent-hover: #b9a0fc;
+                --accent-subtle: rgba(167, 139, 250, 0.1);
+                --accent-surface: rgba(167, 139, 250, 0.04);
+                --color-error: #f87171;
+            }
         }
 
         body {
@@ -30,6 +55,7 @@
             color: var(--fg);
             min-height: 100vh;
             padding: 2rem;
+            -webkit-font-smoothing: antialiased;
         }
 
         .container {
@@ -40,10 +66,11 @@
         .back-link {
             font-family: 'IBM Plex Mono', monospace;
             font-size: 0.75rem;
-            color: var(--fg-muted);
+            color: var(--fg-faint);
             text-decoration: none;
             margin-bottom: 2rem;
             display: inline-block;
+            transition: color 0.15s;
         }
 
         .back-link:hover {
@@ -53,7 +80,7 @@
         .entry {
             background: var(--surface);
             border: 1px solid var(--border);
-            border-radius: 8px;
+            border-radius: 6px;
             padding: 1.5rem;
             margin-bottom: 1.5rem;
         }
@@ -137,7 +164,7 @@
         }
 
         .error {
-            color: #c53030;
+            color: var(--color-error);
         }
 
         /* Reply form */
@@ -233,7 +260,7 @@
 
         .reply-entry {
             background: var(--surface);
-            border: 1px solid #dfd9ef;
+            border: 1px solid var(--border);
             border-left: 3px solid var(--accent);
             border-radius: 6px;
             padding: 1rem 1.25rem;

--- a/index.html
+++ b/index.html
@@ -16,12 +16,55 @@
         }
 
         :root {
-            --bg: #faf9f7;
-            --surface: #ffffff;
-            --border: #e8e6e3;
-            --fg: #1a1a1a;
-            --fg-muted: #6b6b6b;
+            --bg: #e8e4db;
+            --surface: #f4f2ec;
+            --surface-raised: #fdfcf9;
+            --border: #c9c3b8;
+            --border-subtle: #dbd6cc;
+            --fg: #1c1917;
+            --fg-muted: #57534e;
+            --fg-faint: #78716c;
             --accent: #7c5cbf;
+            --accent-hover: #6b4dab;
+            --accent-subtle: rgba(124, 92, 191, 0.08);
+            --accent-surface: rgba(124, 92, 191, 0.04);
+
+            /* Semantic colors */
+            --color-error: #dc2626;
+            --color-error-soft: rgba(220, 38, 38, 0.1);
+            --color-success: #16a34a;
+            --color-success-soft: rgba(22, 163, 74, 0.1);
+            --color-warning: #d97706;
+            --color-warning-soft: rgba(217, 119, 6, 0.1);
+            --color-pending: #a07810;
+            --color-pending-soft: rgba(180, 130, 20, 0.1);
+
+            /* Typography scale */
+            --text-2xs: 0.7rem;
+            --text-xs: 0.8rem;
+            --text-sm: 0.9rem;
+            --text-base: 1.05rem;
+            --text-md: 1.15rem;
+            --text-lg: 1.3rem;
+            --text-xl: 1.65rem;
+            --text-2xl: 2rem;
+
+            /* Spacing */
+            --space-1: 0.25rem;
+            --space-2: 0.5rem;
+            --space-3: 0.75rem;
+            --space-4: 1rem;
+            --space-5: 1.25rem;
+            --space-6: 1.5rem;
+            --space-8: 2rem;
+            --space-10: 2.5rem;
+            --space-12: 3rem;
+            --space-16: 4rem;
+
+            /* Radii */
+            --radius-sm: 3px;
+            --radius-md: 6px;
+            --radius-lg: 8px;
         }
 
         body {
@@ -29,11 +72,13 @@
             background: var(--bg);
             color: var(--fg);
             min-height: 100vh;
+            font-size: 16px;
+            -webkit-font-smoothing: antialiased;
         }
 
         .container {
             display: grid;
-            grid-template-columns: 340px 1fr;
+            grid-template-columns: 320px 1fr;
             min-height: 100vh;
         }
 
@@ -42,7 +87,7 @@
             position: sticky;
             top: 0;
             height: 100vh;
-            padding: 2rem 1.5rem;
+            padding: var(--space-8) var(--space-6);
             border-right: 1px solid var(--border);
             display: flex;
             flex-direction: column;
@@ -50,85 +95,94 @@
         }
 
         .brand {
-            margin-bottom: 0.25rem;
+            margin-bottom: var(--space-1);
         }
 
         .brand h1 {
-            font-size: 1.5rem;
+            font-size: var(--text-xl);
             font-weight: 500;
             font-style: italic;
-            letter-spacing: -0.02em;
+            letter-spacing: -0.03em;
         }
 
         .tagline {
             color: var(--fg-muted);
-            font-size: 1rem;
-            margin-bottom: 2rem;
+            font-size: var(--text-base);
+            line-height: 1.5;
+            margin-bottom: var(--space-8);
         }
 
         .explainer {
             flex: 1;
             overflow-y: auto;
+            padding-right: var(--space-1);
         }
 
         .explainer-section {
-            margin-bottom: 1.5rem;
+            margin-bottom: var(--space-6);
+            padding-bottom: var(--space-6);
+            border-bottom: 1px solid var(--border-subtle);
+        }
+
+        .explainer-section:last-child {
+            border-bottom: none;
         }
 
         .explainer h2 {
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.65rem;
+            font-size: var(--text-2xs);
             font-weight: 500;
             text-transform: uppercase;
-            letter-spacing: 0.1em;
-            color: var(--fg-muted);
-            margin-bottom: 0.75rem;
+            letter-spacing: 0.12em;
+            color: var(--fg-faint);
+            margin-bottom: var(--space-3);
         }
 
         .explainer p {
             color: var(--fg-muted);
-            font-size: 0.95rem;
+            font-size: var(--text-base);
             line-height: 1.7;
-            margin-bottom: 0.5rem;
+            margin-bottom: var(--space-2);
         }
 
         .links {
             display: flex;
             flex-direction: column;
-            gap: 0.5rem;
-            margin-top: 0.75rem;
+            gap: var(--space-2);
+            margin-top: var(--space-3);
         }
 
         .links a {
             color: var(--accent);
             text-decoration: none;
             font-size: 0.9rem;
-            transition: opacity 0.2s;
+            transition: color 0.2s;
         }
 
         .links a:hover {
-            opacity: 0.7;
+            color: var(--accent-hover);
         }
 
         .sidebar-btn {
             display: block;
             width: 100%;
-            background: var(--accent);
+            background: var(--fg);
             border: none;
-            border-radius: 4px;
-            padding: 0.6rem 0.75rem;
+            border-radius: var(--radius-md);
+            padding: 0.65rem 0.75rem;
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
-            color: white !important;
+            font-size: var(--text-xs);
+            color: var(--surface) !important;
             cursor: pointer;
-            transition: all 0.2s;
-            margin-top: 1rem;
+            transition: all 0.15s ease;
+            margin-top: var(--space-4);
             text-decoration: none;
             text-align: center;
+            letter-spacing: 0.02em;
         }
 
         .sidebar-btn:hover {
-            opacity: 0.9;
+            background: var(--accent);
         }
 
         .onboard-wrapper {
@@ -137,19 +191,19 @@
         }
 
         .onboard-wrapper .sidebar-btn.menu-open {
-            border-radius: 4px 4px 0 0;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+            border-radius: var(--radius-md) var(--radius-md) 0 0;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
         }
 
         .onboard-menu {
             display: none;
             flex-direction: column;
-            gap: 0.15rem;
-            padding: 0.4rem 0.75rem 0.5rem;
-            background: var(--surface);
+            gap: var(--space-1);
+            padding: var(--space-2) var(--space-3);
+            background: var(--surface-raised);
             border: 1px solid var(--border);
             border-top: none;
-            border-radius: 0 0 4px 4px;
+            border-radius: 0 0 var(--radius-md) var(--radius-md);
         }
 
         .onboard-menu.open {
@@ -162,11 +216,12 @@
             border: none;
             color: var(--fg-muted);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.65rem;
+            font-size: var(--text-2xs);
             text-decoration: none;
             cursor: pointer;
-            padding: 0.25rem 0;
+            padding: var(--space-1) 0;
             text-align: left;
+            transition: color 0.15s;
         }
 
         .onboard-menu a:hover,
@@ -186,22 +241,22 @@
             font-size: 0.9rem;
             cursor: pointer;
             padding: 0;
-            transition: opacity 0.2s;
+            transition: color 0.15s;
         }
 
         .verify-btn:hover {
-            opacity: 0.7;
+            color: var(--accent-hover);
         }
 
         .verify-menu {
             display: none;
             flex-direction: column;
-            gap: 0.25rem;
-            margin-top: 0.5rem;
-            padding: 0.5rem 0.75rem;
-            background: var(--surface);
+            gap: var(--space-1);
+            margin-top: var(--space-2);
+            padding: var(--space-2) var(--space-3);
+            background: var(--surface-raised);
             border: 1px solid var(--border);
-            border-radius: 4px;
+            border-radius: var(--radius-md);
         }
 
         .verify-menu.open {
@@ -214,12 +269,12 @@
             border: none;
             color: var(--fg-muted);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
+            font-size: var(--text-xs);
             text-decoration: none;
             cursor: pointer;
-            padding: 0.25rem 0;
+            padding: var(--space-1) 0;
             text-align: left;
-            transition: color 0.2s;
+            transition: color 0.15s;
         }
 
         .verify-menu a:hover,
@@ -230,70 +285,71 @@
         .identity-label {
             display: block;
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.65rem;
+            font-size: var(--text-2xs);
             text-transform: uppercase;
-            letter-spacing: 0.05em;
-            color: var(--fg-muted);
-            margin-bottom: 0.25rem;
+            letter-spacing: 0.08em;
+            color: var(--fg-faint);
+            margin-bottom: var(--space-1);
         }
 
         .identity-pseudonym {
             display: block;
             color: var(--accent);
-            font-size: 0.9rem;
-            margin-bottom: 0.35rem;
+            font-size: var(--text-base);
+            margin-bottom: var(--space-1);
         }
 
         .identity-configure {
-            font-size: 0.75rem;
+            font-size: var(--text-xs);
             color: var(--fg-muted);
         }
 
         .identity-handle {
             display: block;
             color: var(--accent);
-            font-size: 0.9rem;
-            margin-bottom: 0.35rem;
+            font-size: var(--text-base);
+            margin-bottom: var(--space-1);
             text-decoration: none;
+            transition: opacity 0.15s;
         }
 
         .identity-handle:hover {
-            text-decoration: underline;
+            opacity: 0.8;
         }
 
         .identity-claim {
             display: block;
-            font-size: 0.8rem;
+            font-size: var(--text-sm);
             color: var(--accent);
             font-weight: 500;
-            margin-top: 0.25rem;
+            margin-top: var(--space-1);
         }
 
         .footer {
             margin-top: auto;
-            padding-top: 2rem;
-            border-top: 1px solid var(--border);
+            padding-top: var(--space-6);
+            border-top: 1px solid var(--border-subtle);
         }
 
         .footer a {
             font-family: 'IBM Plex Mono', monospace;
-            color: var(--fg-muted);
+            color: var(--fg-faint);
             text-decoration: none;
-            font-size: 0.75rem;
+            font-size: var(--text-xs);
             letter-spacing: 0.02em;
             transition: color 0.2s;
         }
 
         .footer a:hover {
-            color: var(--fg);
+            color: var(--fg-muted);
         }
 
         .search-header {
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.8rem;
+            font-size: var(--text-sm);
             color: var(--fg-muted);
-            padding-bottom: 1rem;
-            margin-bottom: 1rem;
+            padding-bottom: var(--space-4);
+            margin-bottom: var(--space-4);
             border-bottom: 1px solid var(--border);
         }
 
@@ -306,13 +362,13 @@
 
         .feed {
             flex: 1;
-            padding: 2rem 3rem;
-            max-width: 680px;
+            padding: var(--space-10) var(--space-12);
+            max-width: 720px;
         }
 
         .entry {
-            padding: 2rem 0;
-            border-bottom: 1px solid var(--border);
+            padding: var(--space-8) 0;
+            border-bottom: 1px solid var(--border-subtle);
         }
 
         .entry:first-child {
@@ -321,132 +377,133 @@
 
         .entry-header {
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
-            color: var(--fg-muted);
+            font-size: var(--text-xs);
+            color: var(--fg-faint);
             letter-spacing: 0.02em;
-            margin-bottom: 0.75rem;
+            margin-bottom: var(--space-3);
         }
 
         .entry-content {
-            font-size: 1.15rem;
-            line-height: 1.75;
+            font-size: var(--text-lg);
+            line-height: 1.8;
             color: var(--fg);
         }
 
         .entry-meta {
-            margin-top: 1rem;
+            margin-top: var(--space-4);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
-            color: var(--fg-muted);
+            font-size: var(--text-xs);
+            color: var(--fg-faint);
             letter-spacing: 0.02em;
         }
 
         .entry-pseudonym {
             color: var(--accent);
             cursor: pointer;
+            transition: opacity 0.15s;
         }
 
         .entry-pseudonym:hover {
-            text-decoration: underline;
+            opacity: 0.8;
         }
 
         .entry-handle {
             color: var(--accent);
             text-decoration: none;
+            transition: opacity 0.15s;
         }
 
         .entry-handle:hover {
-            text-decoration: underline;
+            opacity: 0.8;
         }
 
         .entry-recipients {
             display: flex;
             flex-wrap: wrap;
-            gap: 0.35rem;
+            gap: var(--space-1);
             align-items: center;
-            margin-top: 0.5rem;
+            margin-top: var(--space-2);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
+            font-size: var(--text-xs);
             color: var(--fg-muted);
         }
 
         .entry-recipients-label {
-            opacity: 0.7;
+            opacity: 0.6;
         }
 
         .recipient-tag {
             display: inline-block;
             padding: 0.1rem 0.45rem;
-            border-radius: 3px;
-            background: rgba(124, 92, 191, 0.1);
+            border-radius: var(--radius-sm);
+            background: var(--accent-subtle);
             color: var(--accent);
             text-decoration: none;
             transition: background 0.15s;
         }
 
         .recipient-tag:hover {
-            background: rgba(124, 92, 191, 0.2);
+            background: rgba(124, 92, 191, 0.15);
             text-decoration: none;
         }
 
         .recipient-tag--muted {
-            background: rgba(0, 0, 0, 0.04);
+            background: rgba(0, 0, 0, 0.03);
             color: var(--fg-muted);
         }
 
         .reply-indicator {
-            color: #888;
+            color: var(--fg-faint);
             font-size: 0.9em;
         }
 
         .reply-link {
-            color: #888;
+            color: var(--fg-faint);
             text-decoration: none;
+            transition: color 0.15s;
         }
 
         .reply-link:hover {
             color: var(--accent);
-            text-decoration: underline;
         }
 
         .reply-action {
-            color: var(--fg-muted);
+            color: var(--fg-faint);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
+            font-size: var(--text-xs);
             text-decoration: none;
-            opacity: 0.6;
-            transition: opacity 0.2s;
+            transition: color 0.15s;
             cursor: pointer;
             background: none;
             border: none;
         }
 
         .reply-action:hover {
-            opacity: 1;
             color: var(--accent);
         }
 
         .reply-form {
-            margin-top: 0.75rem;
-            padding: 0.75rem;
+            margin-top: var(--space-3);
+            padding: var(--space-3);
             background: var(--bg);
             border: 1px solid var(--border);
-            border-radius: 6px;
+            border-radius: var(--radius-md);
             position: relative;
         }
 
         .reply-form textarea {
             width: 100%;
-            padding: 0.6rem;
+            padding: var(--space-3);
             border: 1px solid var(--border);
-            border-radius: 4px;
+            border-radius: var(--radius-md);
             font-family: inherit;
-            font-size: 0.9rem;
+            font-size: var(--text-base);
             background: var(--surface);
             color: var(--fg);
             resize: vertical;
             min-height: 60px;
             line-height: 1.5;
+            transition: border-color 0.15s;
         }
 
         .reply-form textarea:focus {
@@ -456,39 +513,40 @@
 
         .reply-form-actions {
             display: flex;
-            gap: 0.75rem;
+            gap: var(--space-3);
             align-items: center;
-            margin-top: 0.5rem;
+            margin-top: var(--space-2);
         }
 
         .reply-form .submit-btn {
             padding: 0.4rem 0.9rem;
-            border-radius: 4px;
+            border-radius: var(--radius-md);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.75rem;
+            font-size: var(--text-xs);
             cursor: pointer;
-            background: var(--accent);
+            background: var(--fg);
             border: none;
-            color: white;
-            transition: opacity 0.2s;
+            color: var(--surface);
+            transition: all 0.15s ease;
         }
 
         .reply-form .submit-btn:hover {
-            opacity: 0.9;
+            background: var(--accent);
         }
 
         .reply-form .submit-btn:disabled {
-            opacity: 0.5;
+            opacity: 0.4;
             cursor: not-allowed;
         }
 
         .reply-form .cancel-btn {
             background: none;
             border: none;
-            color: var(--fg-muted);
+            color: var(--fg-faint);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.75rem;
+            font-size: var(--text-xs);
             cursor: pointer;
+            transition: color 0.15s;
         }
 
         .reply-form .cancel-btn:hover {
@@ -496,63 +554,61 @@
         }
 
         .replies-container {
-            margin-top: 0.9rem;
-            margin-left: 0.75rem;
-            padding: 0.75rem 0.9rem;
-            border-left: 2px solid var(--accent);
-            background: rgba(124, 92, 191, 0.03);
-            border-radius: 0 6px 6px 0;
+            margin-top: var(--space-4);
+            margin-left: var(--space-4);
+            padding: var(--space-3) var(--space-4);
+            border-left: 2px solid var(--border);
+            background: var(--accent-surface);
+            border-radius: 0 var(--radius-md) var(--radius-md) 0;
         }
 
         .replies-container .entry {
-            padding: 0.75rem 0.9rem;
-            margin-bottom: 0.6rem;
-            border: 1px solid #dfd9ef;
-            border-radius: 6px;
+            padding: var(--space-3) var(--space-4);
+            margin-bottom: var(--space-2);
+            border: 1px solid var(--border-subtle);
+            border-radius: var(--radius-md);
             background: var(--surface);
         }
 
         .replies-container .entry-header {
-            font-size: 0.75rem;
+            font-size: var(--text-xs);
             color: var(--fg-muted);
         }
 
         .replies-container .entry-content {
-            font-size: 0.95rem;
+            font-size: var(--text-base);
             line-height: 1.6;
             white-space: pre-wrap;
         }
 
         .replies-container .entry-meta {
-            font-size: 0.65rem;
+            font-size: var(--text-2xs);
         }
 
         .replies-header {
             display: flex;
             align-items: center;
             justify-content: space-between;
-            margin-bottom: 0.6rem;
+            margin-bottom: var(--space-2);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.68rem;
-            color: var(--fg-muted);
+            font-size: var(--text-2xs);
+            color: var(--fg-faint);
             text-transform: uppercase;
-            letter-spacing: 0.04em;
+            letter-spacing: 0.05em;
         }
 
         .replies-toggle {
-            color: var(--fg-muted);
+            color: var(--fg-faint);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
+            font-size: var(--text-xs);
             text-decoration: none;
-            opacity: 0.6;
-            transition: opacity 0.2s;
+            transition: color 0.15s;
             cursor: pointer;
             background: none;
             border: none;
         }
 
         .replies-toggle:hover {
-            opacity: 1;
             color: var(--accent);
         }
 
@@ -560,156 +616,119 @@
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            width: 1.4rem;
-            height: 1.4rem;
+            width: 1.35rem;
+            height: 1.35rem;
             border-radius: 50%;
-            font-size: 0.7rem;
+            font-size: 0.65rem;
             font-weight: 600;
             color: white;
             text-transform: uppercase;
             vertical-align: middle;
-            margin-right: 0.3rem;
+            margin-right: var(--space-1);
         }
 
         .avatar-small {
-            width: 1.1rem;
-            height: 1.1rem;
-            font-size: 0.55rem;
-            margin-right: 0.25rem;
+            width: 1.05rem;
+            height: 1.05rem;
+            font-size: 0.5rem;
+            margin-right: var(--space-1);
         }
 
-        .delete-btn {
+        .delete-btn,
+        .publish-btn,
+        .copy-link-action {
             background: none;
             border: none;
-            color: var(--fg-muted);
+            color: var(--fg-faint);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
+            font-size: var(--text-xs);
             cursor: pointer;
-            opacity: 0.5;
-            transition: opacity 0.2s;
+            transition: color 0.15s;
+            padding: 0;
         }
 
         .delete-btn:hover {
-            opacity: 1;
-            color: #e53935;
+            color: var(--color-error);
         }
 
-        .publish-btn {
-            background: none;
-            border: none;
-            color: var(--fg-muted);
-            font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
-            cursor: pointer;
-            opacity: 0.5;
-            transition: opacity 0.2s;
-        }
-
-        .publish-btn:hover {
-            opacity: 1;
+        .publish-btn:hover,
+        .copy-link-action:hover {
             color: var(--accent);
         }
 
         .discuss-link {
             color: var(--accent);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
+            font-size: var(--text-xs);
             text-decoration: none;
             opacity: 0.8;
-            transition: opacity 0.2s;
+            transition: opacity 0.15s;
         }
 
         .discuss-link:hover {
             opacity: 1;
-            text-decoration: underline;
         }
 
         .permalink {
-            color: var(--fg-muted);
+            color: var(--fg-faint);
             text-decoration: none;
+            transition: color 0.15s;
         }
 
         .permalink:hover {
-            text-decoration: underline;
-        }
-
-        .copy-link-action {
-            background: none;
-            border: none;
             color: var(--fg-muted);
-            font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
-            cursor: pointer;
-            opacity: 0.65;
-            transition: opacity 0.2s;
-            padding: 0;
         }
 
-        .copy-link-action:hover {
-            opacity: 1;
-            color: var(--accent);
-        }
-
-        /* Unified badge system */
-        .meta-badge {
+        /* Badge system */
+        .meta-badge,
+        .pending-badge,
+        .only-you-badge,
+        .reflection-badge,
+        .platform-badge,
+        .thread-badge,
+        .session-badge,
+        .note-badge {
             display: inline-block;
-            padding: 0.15rem 0.4rem;
-            border-radius: 3px;
+            padding: 0.12rem 0.4rem;
+            border-radius: var(--radius-sm);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.65rem;
+            font-size: var(--text-2xs);
             text-transform: uppercase;
             letter-spacing: 0.05em;
             vertical-align: middle;
         }
 
-        .meta-badge--pending {
-            background: rgba(124, 92, 191, 0.15);
+        .meta-badge--pending,
+        .pending-badge,
+        .meta-badge--type,
+        .reflection-badge,
+        .thread-badge,
+        .session-badge,
+        .note-badge {
+            background: var(--accent-subtle);
             color: var(--accent);
         }
 
-        .meta-badge--type {
-            background: rgba(124, 92, 191, 0.1);
-            color: var(--accent);
+        .meta-badge--source,
+        .platform-badge {
+            background: var(--border-subtle);
+            color: var(--fg-muted);
         }
 
-        .meta-badge--source {
-            background: var(--border);
+        .only-you-badge {
+            background: rgba(100, 100, 100, 0.07);
             color: var(--fg-muted);
         }
 
         .token-count {
-            color: var(--fg-muted);
+            color: var(--fg-faint);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
-        }
-
-        /* Legacy badge aliases */
-        .pending-badge {
-            display: inline-block;
-            padding: 0.15rem 0.4rem;
-            background: rgba(124, 92, 191, 0.15);
-            color: var(--accent);
-            border-radius: 3px;
-            font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.65rem;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-        }
-
-        .only-you-badge {
-            display: inline-block;
-            padding: 0.15rem 0.4rem;
-            background: rgba(100, 100, 100, 0.1);
-            color: var(--fg-muted);
-            border-radius: 3px;
-            font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.65rem;
-            letter-spacing: 0.03em;
+            font-size: var(--text-xs);
         }
 
         .filter-header {
-            padding-bottom: 1.5rem;
-            margin-bottom: 1rem;
+            padding-bottom: var(--space-6);
+            margin-bottom: var(--space-4);
             border-bottom: 1px solid var(--border);
             display: flex;
             justify-content: space-between;
@@ -717,42 +736,44 @@
         }
 
         .filter-header h2 {
-            font-size: 1rem;
+            font-size: var(--text-lg);
             font-weight: 500;
-            color: var(--accent);
+            font-style: italic;
+            color: var(--fg);
         }
 
         .filter-header a {
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.75rem;
-            color: var(--fg-muted);
+            font-size: var(--text-xs);
+            color: var(--fg-faint);
             text-decoration: none;
+            transition: color 0.15s;
         }
 
         .filter-header a:hover {
-            color: var(--fg);
+            color: var(--fg-muted);
         }
 
         /* Inbox styles */
         .inbox-section {
-            margin-bottom: 1.5rem;
+            margin-bottom: var(--space-6);
         }
 
         .inbox-section-label {
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
+            font-size: var(--text-xs);
             text-transform: uppercase;
             letter-spacing: 0.08em;
-            color: var(--fg-muted);
-            padding-bottom: 0.5rem;
-            margin-bottom: 0.5rem;
-            border-bottom: 1px solid var(--border);
+            color: var(--fg-faint);
+            padding-bottom: var(--space-2);
+            margin-bottom: var(--space-2);
+            border-bottom: 1px solid var(--border-subtle);
         }
 
         .inbox-item {
             display: block;
-            padding: 0.6rem 0;
-            border-bottom: 1px solid var(--border);
+            padding: var(--space-3) 0;
+            border-bottom: 1px solid var(--border-subtle);
             cursor: pointer;
             text-decoration: none;
             color: inherit;
@@ -760,14 +781,14 @@
         }
 
         .inbox-item:hover {
-            background: rgba(124, 92, 191, 0.04);
+            background: var(--accent-surface);
         }
 
         .inbox-item-row {
             display: flex;
             align-items: baseline;
-            gap: 0.5rem;
-            font-size: 0.85rem;
+            gap: var(--space-2);
+            font-size: var(--text-sm);
         }
 
         .inbox-item-from {
@@ -787,8 +808,8 @@
 
         .inbox-item-time {
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.65rem;
-            color: var(--fg-muted);
+            font-size: var(--text-2xs);
+            color: var(--fg-faint);
             white-space: nowrap;
             flex-shrink: 0;
         }
@@ -796,20 +817,20 @@
         .inbox-item-meta {
             display: flex;
             align-items: center;
-            gap: 0.4rem;
-            margin-top: 0.25rem;
+            gap: var(--space-2);
+            margin-top: var(--space-1);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.65rem;
+            font-size: var(--text-2xs);
         }
 
         .inbox-badge-queued {
             display: inline-block;
             padding: 0.1rem 0.35rem;
-            background: rgba(210, 167, 52, 0.15);
-            color: #b8860b;
-            border-radius: 3px;
+            background: var(--color-pending-soft);
+            color: var(--color-pending);
+            border-radius: var(--radius-sm);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.6rem;
+            font-size: var(--text-2xs);
             text-transform: uppercase;
             letter-spacing: 0.04em;
         }
@@ -817,73 +838,70 @@
         .inbox-badge-received {
             display: inline-block;
             padding: 0.1rem 0.35rem;
-            background: rgba(124, 92, 191, 0.1);
+            background: var(--accent-subtle);
             color: var(--accent);
-            border-radius: 3px;
+            border-radius: var(--radius-sm);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.6rem;
+            font-size: var(--text-2xs);
             text-transform: uppercase;
             letter-spacing: 0.04em;
         }
 
         .inbox-item-actions {
             display: flex;
-            gap: 0.5rem;
-            margin-top: 0.3rem;
+            gap: var(--space-2);
+            margin-top: var(--space-1);
         }
 
         .inbox-item-actions button {
             background: none;
             border: none;
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.65rem;
+            font-size: var(--text-2xs);
             cursor: pointer;
-            opacity: 0.6;
-            transition: opacity 0.2s;
+            color: var(--fg-faint);
+            transition: color 0.15s;
         }
 
         .inbox-item-actions button:hover {
-            opacity: 1;
+            color: var(--fg);
         }
 
         .inbox-item-actions .publish-btn {
             color: var(--accent);
         }
 
-        .inbox-item-actions .delete-btn {
-            color: var(--fg-muted);
-        }
-
         .inbox-item-actions .delete-btn:hover {
-            color: #e53935;
+            color: var(--color-error);
         }
 
         /* Channel styles */
         .channels-sidebar {
-            margin-bottom: 1rem;
+            margin-bottom: var(--space-4);
         }
 
         .channels-sidebar-list {
-            margin-top: 0.5rem;
+            margin-top: var(--space-2);
         }
 
         .channels-sidebar-list a {
             display: block;
             color: var(--accent);
             text-decoration: none;
-            font-size: 0.9rem;
-            padding: 0.2rem 0;
+            font-size: var(--text-base);
+            padding: var(--space-1) 0;
+            transition: opacity 0.15s;
         }
 
         .channels-sidebar-list a:hover {
-            opacity: 0.7;
+            opacity: 0.8;
         }
 
         .channel-card {
             border: 1px solid var(--border);
-            border-radius: 6px;
-            padding: 1rem;
-            margin-bottom: 1rem;
+            border-radius: var(--radius-md);
+            padding: var(--space-4);
+            margin-bottom: var(--space-4);
             background: var(--surface);
         }
 
@@ -891,47 +909,47 @@
             display: flex;
             justify-content: space-between;
             align-items: flex-start;
-            margin-bottom: 0.5rem;
+            margin-bottom: var(--space-2);
         }
 
         .channel-card-name {
-            font-size: 1rem;
+            font-size: var(--text-md);
             font-weight: 500;
-            color: var(--accent);
+            color: var(--fg);
         }
 
         .channel-card-meta {
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
-            color: var(--fg-muted);
+            font-size: var(--text-xs);
+            color: var(--fg-faint);
         }
 
         .channel-card-description {
             color: var(--fg-muted);
-            font-size: 0.9rem;
+            font-size: var(--text-base);
             line-height: 1.5;
-            margin-bottom: 0.75rem;
+            margin-bottom: var(--space-3);
         }
 
         .channel-card-actions {
             display: flex;
-            gap: 0.5rem;
+            gap: var(--space-2);
         }
 
         .channel-btn {
-            background: var(--accent);
+            background: var(--fg);
             border: none;
-            border-radius: 4px;
+            border-radius: var(--radius-md);
             padding: 0.4rem 0.75rem;
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
-            color: white;
+            font-size: var(--text-xs);
+            color: var(--surface);
             cursor: pointer;
-            transition: opacity 0.2s;
+            transition: all 0.15s ease;
         }
 
         .channel-btn:hover {
-            opacity: 0.85;
+            background: var(--accent);
         }
 
         .channel-btn.secondary {
@@ -942,11 +960,12 @@
 
         .channel-btn.secondary:hover {
             border-color: var(--fg-muted);
+            color: var(--fg);
         }
 
         .channel-header {
-            padding-bottom: 1.5rem;
-            margin-bottom: 1.5rem;
+            padding-bottom: var(--space-6);
+            margin-bottom: var(--space-6);
             border-bottom: 1px solid var(--border);
         }
 
@@ -954,36 +973,37 @@
             display: flex;
             justify-content: space-between;
             align-items: flex-start;
-            margin-bottom: 0.5rem;
+            margin-bottom: var(--space-2);
         }
 
         .channel-header-name {
-            font-size: 1.25rem;
+            font-size: var(--text-xl);
             font-weight: 500;
-            color: var(--accent);
+            font-style: italic;
+            color: var(--fg);
         }
 
         .channel-header-description {
             color: var(--fg-muted);
-            font-size: 0.95rem;
+            font-size: var(--text-base);
             line-height: 1.6;
-            margin-bottom: 0.75rem;
+            margin-bottom: var(--space-3);
         }
 
         .channel-header-meta {
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
-            color: var(--fg-muted);
+            font-size: var(--text-xs);
+            color: var(--fg-faint);
         }
 
         .channel-section-label {
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
+            font-size: var(--text-xs);
             text-transform: uppercase;
             letter-spacing: 0.08em;
-            color: var(--fg-muted);
-            margin-bottom: 1rem;
-            margin-top: 1.5rem;
+            color: var(--fg-faint);
+            margin-bottom: var(--space-4);
+            margin-top: var(--space-6);
         }
 
         .channel-section-label:first-child {
@@ -992,16 +1012,16 @@
 
         .channel-create-form {
             border: 1px solid var(--border);
-            border-radius: 6px;
-            padding: 1rem;
+            border-radius: var(--radius-md);
+            padding: var(--space-4);
             background: var(--surface);
-            margin-top: 1.5rem;
+            margin-top: var(--space-6);
         }
 
         .channel-create-form h3 {
-            font-size: 0.9rem;
+            font-size: var(--text-base);
             font-weight: 500;
-            margin-bottom: 1rem;
+            margin-bottom: var(--space-4);
         }
 
         .channel-create-form input,
@@ -1009,13 +1029,22 @@
         .channel-create-form select {
             display: block;
             width: 100%;
-            padding: 0.5rem;
-            margin-bottom: 0.75rem;
+            padding: var(--space-2);
+            margin-bottom: var(--space-3);
             border: 1px solid var(--border);
-            border-radius: 4px;
+            border-radius: var(--radius-md);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.8rem;
+            font-size: var(--text-sm);
             background: var(--bg);
+            color: var(--fg);
+            transition: border-color 0.15s;
+        }
+
+        .channel-create-form input:focus,
+        .channel-create-form textarea:focus,
+        .channel-create-form select:focus {
+            outline: none;
+            border-color: var(--accent);
         }
 
         .channel-create-form textarea {
@@ -1026,92 +1055,93 @@
         .channel-create-form label {
             display: block;
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
-            color: var(--fg-muted);
-            margin-bottom: 0.25rem;
+            font-size: var(--text-xs);
+            color: var(--fg-faint);
+            margin-bottom: var(--space-1);
         }
 
         /* Empty state */
         .empty-state {
-            padding: 4rem 0;
+            padding: var(--space-16) 0;
             color: var(--fg-muted);
             font-style: italic;
         }
 
         .loading-state {
-            padding: 4rem 0;
-            color: var(--fg-muted);
+            padding: var(--space-16) 0;
+            color: var(--fg-faint);
             font-style: italic;
             text-align: center;
         }
 
         .load-more-container {
-            padding: 2rem 0;
+            padding: var(--space-8) 0;
             text-align: center;
         }
 
         .load-more-btn {
-            background: var(--bg-surface);
+            background: var(--surface);
             border: 1px solid var(--border);
-            color: var(--fg);
-            padding: 0.75rem 2rem;
-            border-radius: 4px;
+            color: var(--fg-muted);
+            padding: var(--space-3) var(--space-8);
+            border-radius: var(--radius-md);
             cursor: pointer;
-            font-size: 0.9rem;
-            transition: background 0.15s, border-color 0.15s;
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: var(--text-xs);
+            letter-spacing: 0.02em;
+            transition: all 0.15s ease;
         }
 
         .load-more-btn:hover {
-            background: var(--bg-hover);
             border-color: var(--fg-muted);
+            color: var(--fg);
         }
 
         .load-more-btn:disabled {
-            opacity: 0.5;
+            opacity: 0.4;
             cursor: not-allowed;
         }
 
         /* Loading */
         .loading {
-            padding: 4rem 0;
-            color: var(--fg-muted);
+            padding: var(--space-16) 0;
+            color: var(--fg-faint);
             font-style: italic;
         }
 
         /* Summaries - thread style */
         .summary {
-            padding: 2rem 0;
-            border-bottom: 1px solid var(--border);
+            padding: var(--space-8) 0;
+            border-bottom: 1px solid var(--border-subtle);
         }
 
         .summary-content {
-            font-size: 1.15rem;
-            line-height: 1.75;
+            font-size: var(--text-lg);
+            line-height: 1.8;
             color: var(--fg);
         }
 
         .summary-meta {
-            margin-top: 1rem;
+            margin-top: var(--space-4);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
-            color: var(--fg-muted);
+            font-size: var(--text-xs);
+            color: var(--fg-faint);
             letter-spacing: 0.02em;
         }
 
         .summary-toggle {
             color: var(--accent);
             cursor: pointer;
-            transition: opacity 0.2s;
+            transition: opacity 0.15s;
         }
 
         .summary-toggle:hover {
-            opacity: 0.7;
-            text-decoration: underline;
+            opacity: 0.8;
         }
 
         .summary-entries {
-            margin-top: 1.25rem;
-            padding-left: 1rem;
+            margin-top: var(--space-5);
+            padding-left: var(--space-4);
             border-left: 2px solid var(--border);
             display: none;
         }
@@ -1121,7 +1151,7 @@
         }
 
         .summary-entries .entry {
-            padding: 0.75rem 0;
+            padding: var(--space-3) 0;
         }
 
         .summary-entries .entry:first-child {
@@ -1129,14 +1159,14 @@
         }
 
         .summary-entries .entry-content {
-            font-size: 0.95rem;
+            font-size: var(--text-base);
             line-height: 1.6;
             color: var(--fg-muted);
         }
 
         .summary-entries .entry-meta {
-            margin-top: 0.5rem;
-            font-size: 0.65rem;
+            margin-top: var(--space-2);
+            font-size: var(--text-2xs);
         }
 
         /* Daily summaries */
@@ -1147,28 +1177,29 @@
         .day-header {
             display: flex;
             align-items: baseline;
-            gap: 1rem;
-            padding: 3rem 0 1.5rem 0;
+            gap: var(--space-4);
+            padding: var(--space-16) 0 var(--space-6) 0;
         }
 
         .day-header:first-child {
-            padding-top: 0;
+            padding-top: var(--space-2);
         }
 
         .day-header-text {
             font-family: 'Newsreader', Georgia, serif;
-            font-size: 1.75rem;
-            font-weight: 500;
+            font-size: var(--text-2xl);
+            font-weight: 400;
             font-style: italic;
             color: var(--fg);
             white-space: nowrap;
+            letter-spacing: -0.02em;
         }
 
         .day-header-date {
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.8rem;
-            color: var(--fg-muted);
-            letter-spacing: 0.02em;
+            font-size: var(--text-xs);
+            color: var(--fg-faint);
+            letter-spacing: 0.03em;
         }
 
         .day-header-line {
@@ -1179,12 +1210,12 @@
         }
 
         .daily-intro {
-            padding: 0.5rem 0 1.5rem 0;
-            border-bottom: 1px solid var(--border);
+            padding: var(--space-2) 0 var(--space-6) 0;
+            border-bottom: 1px solid var(--border-subtle);
         }
 
         .daily-intro-content {
-            font-size: 1.1rem;
+            font-size: var(--text-md);
             line-height: 1.7;
             color: var(--fg-muted);
             font-style: italic;
@@ -1201,11 +1232,20 @@
                 height: auto;
                 border-right: none;
                 border-bottom: 1px solid var(--border);
-                padding: 2rem 1.5rem;
+                padding: var(--space-6) var(--space-6);
             }
 
             .feed {
-                padding: 1.5rem;
+                padding: var(--space-6);
+            }
+
+            .top-toolbar {
+                top: var(--space-4);
+                right: var(--space-4);
+            }
+
+            .day-header-text {
+                font-size: var(--text-xl);
             }
         }
 
@@ -1271,18 +1311,18 @@
 
         .entry-content.reflection code {
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.9em;
-            background: var(--border);
+            font-size: 0.88em;
+            background: var(--border-subtle);
             padding: 0.15rem 0.35rem;
-            border-radius: 3px;
+            border-radius: var(--radius-sm);
         }
 
         .entry-content.reflection pre {
-            background: var(--border);
-            padding: 1rem;
-            border-radius: 4px;
+            background: var(--border-subtle);
+            padding: var(--space-4);
+            border-radius: var(--radius-md);
             overflow-x: auto;
-            margin: 1rem 0;
+            margin: var(--space-4) 0;
         }
 
         .entry-content.reflection pre code {
@@ -1298,80 +1338,67 @@
             font-weight: 500;
         }
 
-        .reflection-badge {
-            display: inline-block;
-            padding: 0.15rem 0.4rem;
-            background: rgba(124, 92, 191, 0.1);
-            color: var(--accent);
-            border-radius: 3px;
-            font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.65rem;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            vertical-align: middle;
-        }
+        /* reflection-badge styles consolidated into badge system above */
 
         /* Top toolbar - fixed top right */
         .top-toolbar {
             position: fixed;
-            top: 1.5rem;
-            right: 1.5rem;
+            top: var(--space-6);
+            right: var(--space-6);
             display: flex;
             align-items: center;
-            gap: 0.5rem;
+            gap: var(--space-2);
             z-index: 100;
         }
 
         .toolbar-btn {
-            width: 36px;
-            height: 36px;
+            position: relative;
+            width: 34px;
+            height: 34px;
             background: var(--surface);
             border: 1px solid var(--border);
-            border-radius: 6px;
+            border-radius: var(--radius-md);
             cursor: pointer;
             display: flex;
             align-items: center;
             justify-content: center;
-            transition: all 0.2s;
-            color: var(--fg-muted);
+            transition: all 0.15s ease;
+            color: var(--fg-faint);
         }
 
         .toolbar-btn:hover {
-            border-color: var(--accent);
-            color: var(--accent);
+            border-color: var(--fg-muted);
+            color: var(--fg);
+            background: var(--surface-raised);
         }
 
         .toolbar-btn svg {
-            width: 18px;
-            height: 18px;
-        }
-
-        .toolbar-btn {
-            position: relative;
+            width: 16px;
+            height: 16px;
         }
 
         .join-status-banner {
             position: fixed;
-            top: 16px;
-            right: 16px;
+            top: var(--space-4);
+            right: var(--space-4);
             z-index: 1100;
-            padding: 0.6rem 0.8rem;
-            border-radius: 8px;
+            padding: var(--space-3) var(--space-4);
+            border-radius: var(--radius-lg);
             border: 1px solid var(--border);
-            background: var(--surface);
+            background: var(--surface-raised);
             color: var(--fg);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.75rem;
-            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+            font-size: var(--text-xs);
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
             max-width: 360px;
         }
 
         .join-status-banner.success {
-            border-color: rgba(129, 199, 132, 0.5);
+            border-color: color-mix(in srgb, var(--color-success) 30%, transparent);
         }
 
         .join-status-banner.error {
-            border-color: rgba(229, 115, 115, 0.6);
+            border-color: color-mix(in srgb, var(--color-error) 30%, transparent);
         }
 
         .notif-badge {
@@ -1382,7 +1409,7 @@
             height: 16px;
             padding: 0 4px;
             border-radius: 8px;
-            background: #e53935;
+            background: var(--color-error);
             color: white;
             font-family: 'IBM Plex Mono', monospace;
             font-size: 0.55rem;
@@ -1394,13 +1421,13 @@
         .search-container {
             display: flex;
             align-items: center;
-            gap: 0.5rem;
+            gap: var(--space-2);
         }
 
         .search-container.expanded .search-input {
             width: 200px;
             opacity: 1;
-            padding: 0.5rem 0.75rem;
+            padding: var(--space-2) var(--space-3);
         }
 
         .search-container .search-input {
@@ -1408,9 +1435,9 @@
             opacity: 0;
             padding: 0;
             border: 1px solid var(--border);
-            border-radius: 6px;
+            border-radius: var(--radius-md);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.8rem;
+            font-size: var(--text-sm);
             background: var(--surface);
             color: var(--fg);
             transition: all 0.2s;
@@ -1422,7 +1449,7 @@
         }
 
         .search-container .search-input::placeholder {
-            color: var(--fg-muted);
+            color: var(--fg-faint);
         }
 
         /* Modal */
@@ -1432,7 +1459,8 @@
             left: 0;
             right: 0;
             bottom: 0;
-            background: rgba(0, 0, 0, 0.5);
+            background: rgba(10, 10, 12, 0.5);
+            backdrop-filter: blur(4px);
             display: flex;
             align-items: center;
             justify-content: center;
@@ -1444,45 +1472,52 @@
         }
 
         .modal-content {
-            background: var(--surface);
-            border-radius: 8px;
-            padding: 2rem;
-            max-width: 500px;
+            background: var(--surface-raised);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: var(--space-8);
+            max-width: 480px;
             width: 90%;
             max-height: 90vh;
             overflow-y: auto;
+            box-shadow: 0 16px 48px rgba(0, 0, 0, 0.12);
         }
 
         .modal-content h2 {
-            font-size: 1.25rem;
-            margin-bottom: 0.5rem;
+            font-size: var(--text-xl);
+            font-weight: 500;
+            font-style: italic;
+            margin-bottom: var(--space-2);
         }
 
         .modal-content p {
             color: var(--fg-muted);
-            font-size: 0.9rem;
-            margin-bottom: 1.5rem;
+            font-size: var(--text-base);
+            margin-bottom: var(--space-6);
+            line-height: 1.6;
         }
 
         .modal-content label {
             display: block;
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
+            font-size: var(--text-2xs);
             text-transform: uppercase;
-            color: var(--fg-muted);
-            margin-bottom: 0.5rem;
+            letter-spacing: 0.1em;
+            color: var(--fg-faint);
+            margin-bottom: var(--space-2);
         }
 
         .modal-content input {
             width: 100%;
-            padding: 0.75rem;
+            padding: var(--space-3);
             border: 1px solid var(--border);
-            border-radius: 4px;
+            border-radius: var(--radius-md);
             font-family: inherit;
-            font-size: 0.95rem;
+            font-size: var(--text-base);
             background: var(--bg);
             color: var(--fg);
-            margin-bottom: 1rem;
+            margin-bottom: var(--space-4);
+            transition: border-color 0.15s;
         }
 
         .modal-content input:focus {
@@ -1491,7 +1526,7 @@
         }
 
         .modal-hint {
-            font-size: 0.8rem !important;
+            font-size: var(--text-sm) !important;
             color: var(--fg-muted) !important;
             margin-top: -0.5rem;
         }
@@ -1501,91 +1536,97 @@
         }
 
         .modal-warning {
-            font-size: 0.8rem !important;
-            color: #d97706 !important;
-            background: rgba(217, 119, 6, 0.1);
-            padding: 0.5rem 0.75rem;
-            border-radius: 4px;
-            margin-top: 0.5rem;
+            font-size: var(--text-sm) !important;
+            color: var(--color-warning) !important;
+            background: var(--color-warning-soft);
+            padding: var(--space-2) var(--space-3);
+            border-radius: var(--radius-md);
+            margin-top: var(--space-2);
         }
 
         .modal-actions {
             display: flex;
-            gap: 1rem;
-            margin-top: 1.5rem;
+            gap: var(--space-3);
+            margin-top: var(--space-6);
         }
 
         .modal-actions button {
             padding: 0.6rem 1.2rem;
-            border-radius: 4px;
+            border-radius: var(--radius-md);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.8rem;
+            font-size: var(--text-sm);
             cursor: pointer;
-            transition: opacity 0.2s;
+            transition: all 0.15s ease;
         }
 
         .modal-actions .cancel-btn {
             background: none;
             border: 1px solid var(--border);
+            color: var(--fg-muted);
+        }
+
+        .modal-actions .cancel-btn:hover {
+            border-color: var(--fg-muted);
             color: var(--fg);
         }
 
         .modal-actions .submit-btn {
-            background: var(--accent);
+            background: var(--fg);
             border: none;
-            color: white;
+            color: var(--surface);
             flex: 1;
         }
 
-        .modal-actions button:hover {
-            opacity: 0.85;
+        .modal-actions .submit-btn:hover {
+            background: var(--accent);
         }
 
         .modal-actions button:disabled {
-            opacity: 0.5;
+            opacity: 0.4;
             cursor: not-allowed;
         }
 
         .modal-status {
-            margin-top: 1rem;
-            padding: 0.75rem;
-            border-radius: 4px;
-            font-size: 0.85rem;
+            margin-top: var(--space-4);
+            padding: var(--space-3);
+            border-radius: var(--radius-md);
+            font-size: var(--text-sm);
+            font-family: 'IBM Plex Mono', monospace;
         }
 
         .modal-status.error {
-            background: rgba(229, 57, 53, 0.1);
-            color: #e53935;
+            background: var(--color-error-soft);
+            color: var(--color-error);
         }
 
         .modal-status.success {
-            background: rgba(67, 160, 71, 0.1);
-            color: #43a047;
+            background: var(--color-success-soft);
+            color: var(--color-success);
         }
 
         /* Conversation card */
         .conversation {
-            padding: 2rem 0;
-            border-bottom: 1px solid var(--border);
+            padding: var(--space-8) 0;
+            border-bottom: 1px solid var(--border-subtle);
         }
 
         .conversation-summary {
-            font-size: 1.15rem;
-            line-height: 1.75;
+            font-size: var(--text-lg);
+            line-height: 1.8;
             color: var(--fg);
         }
 
         .conversation-meta {
-            margin-top: 1rem;
+            margin-top: var(--space-4);
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.7rem;
-            color: var(--fg-muted);
+            font-size: var(--text-xs);
+            color: var(--fg-faint);
             letter-spacing: 0.02em;
         }
 
         .ai-only-note {
-            margin-top: 0.75rem;
-            font-size: 0.85rem;
+            margin-top: var(--space-3);
+            font-size: var(--text-sm);
             color: var(--fg-muted);
         }
 
@@ -1593,57 +1634,7 @@
             font-style: italic;
         }
 
-        .platform-badge {
-            display: inline-block;
-            padding: 0.15rem 0.4rem;
-            background: var(--border);
-            color: var(--fg-muted);
-            border-radius: 3px;
-            font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.65rem;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            vertical-align: middle;
-        }
-
-        .thread-badge {
-            display: inline-block;
-            padding: 0.15rem 0.4rem;
-            background: rgba(124, 92, 191, 0.1);
-            color: var(--accent);
-            border-radius: 3px;
-            font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.65rem;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            vertical-align: middle;
-        }
-
-        .session-badge {
-            display: inline-block;
-            padding: 0.15rem 0.4rem;
-            background: rgba(124, 92, 191, 0.1);
-            color: var(--accent);
-            border-radius: 3px;
-            font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.65rem;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            vertical-align: middle;
-        }
-
-        .note-badge {
-            display: inline-block;
-            padding: 0.15rem 0.4rem;
-            background: rgba(124, 92, 191, 0.1);
-            color: var(--accent);
-            border-radius: 3px;
-            font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.65rem;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            vertical-align: middle;
-        }
+        /* platform/thread/session/note badge styles consolidated into badge system above */
 
         .view-full {
             color: var(--accent);
@@ -1658,10 +1649,10 @@
 
         /* Full conversation view */
         .conversation-full {
-            margin-top: 1.5rem;
-            padding: 1rem;
+            margin-top: var(--space-6);
+            padding: var(--space-4);
             background: var(--bg);
-            border-radius: 4px;
+            border-radius: var(--radius-md);
             display: none;
         }
 
@@ -1670,12 +1661,12 @@
         }
 
         .conversation-full h3 {
-            font-size: 1rem;
-            margin-bottom: 0.5rem;
+            font-size: var(--text-md);
+            margin-bottom: var(--space-2);
         }
 
         .conversation-full-content {
-            font-size: 0.9rem;
+            font-size: var(--text-base);
             line-height: 1.6;
             color: var(--fg-muted);
             max-height: 400px;
@@ -1687,43 +1678,43 @@
         .conversation-full-content h2,
         .conversation-full-content h3 {
             font-family: 'Newsreader', Georgia, serif;
-            margin: 1rem 0 0.5rem 0;
+            margin: var(--space-4) 0 var(--space-2) 0;
             font-weight: 500;
             color: var(--fg);
         }
 
         .conversation-full-content h1 { font-size: 1.2rem; }
         .conversation-full-content h2 { font-size: 1.1rem; }
-        .conversation-full-content h3 { font-size: 1rem; }
+        .conversation-full-content h3 { font-size: var(--text-md); }
 
         .conversation-full-content p {
-            margin: 0.5rem 0;
+            margin: var(--space-2) 0;
         }
 
         .conversation-full-content ul,
         .conversation-full-content ol {
-            margin: 0.5rem 0;
-            padding-left: 1.5rem;
+            margin: var(--space-2) 0;
+            padding-left: var(--space-6);
         }
 
         .conversation-full-content li {
-            margin: 0.25rem 0;
+            margin: var(--space-1) 0;
         }
 
         .conversation-full-content code {
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.85em;
-            background: var(--border);
+            font-size: 0.88em;
+            background: var(--border-subtle);
             padding: 0.1rem 0.3rem;
-            border-radius: 3px;
+            border-radius: var(--radius-sm);
         }
 
         .conversation-full-content pre {
-            background: var(--border);
-            padding: 0.75rem;
-            border-radius: 4px;
+            background: var(--border-subtle);
+            padding: var(--space-3);
+            border-radius: var(--radius-md);
             overflow-x: auto;
-            margin: 0.75rem 0;
+            margin: var(--space-3) 0;
         }
 
         .conversation-full-content pre code {
@@ -1732,9 +1723,9 @@
         }
 
         .conversation-full-content blockquote {
-            border-left: 3px solid var(--accent);
-            padding-left: 1rem;
-            margin: 0.75rem 0;
+            border-left: 3px solid var(--border);
+            padding-left: var(--space-4);
+            margin: var(--space-3) 0;
             color: var(--fg-muted);
             font-style: italic;
         }
@@ -1742,20 +1733,21 @@
         .mention-link {
             color: var(--accent);
             text-decoration: none;
+            transition: opacity 0.15s;
         }
 
         .mention-link:hover {
-            text-decoration: underline;
+            opacity: 0.8;
         }
 
         .mention-dropdown {
             position: absolute;
             bottom: 100%;
             left: 0;
-            background: var(--surface);
+            background: var(--surface-raised);
             border: 1px solid var(--border);
-            border-radius: 4px;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+            border-radius: var(--radius-md);
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
             max-height: 200px;
             overflow-y: auto;
             z-index: 100;
@@ -1768,10 +1760,10 @@
         }
 
         .mention-option {
-            padding: 0.5rem 0.75rem;
+            padding: var(--space-2) var(--space-3);
             cursor: pointer;
             font-family: 'IBM Plex Mono', monospace;
-            font-size: 0.8rem;
+            font-size: var(--text-sm);
         }
 
         .mention-option:hover,
@@ -1784,19 +1776,42 @@
         }
 
         .mention-option .name {
-            color: var(--fg-muted);
-            margin-left: 0.5rem;
+            color: var(--fg-faint);
+            margin-left: var(--space-2);
         }
 
         /* Dark mode */
         @media (prefers-color-scheme: dark) {
             :root {
-                --bg: #0a0a0b;
-                --surface: #111113;
-                --border: #2a2a2e;
-                --fg: #e4e4e7;
-                --fg-muted: #8b8b8b;
+                --bg: #0e0d0b;
+                --surface: #161513;
+                --surface-raised: #1e1d1a;
+                --border: #2e2c28;
+                --border-subtle: #232220;
+                --fg: #e7e5e0;
+                --fg-muted: #a8a49d;
+                --fg-faint: #6b6860;
                 --accent: #a78bfa;
+                --accent-hover: #b9a0fc;
+                --accent-subtle: rgba(167, 139, 250, 0.1);
+                --accent-surface: rgba(167, 139, 250, 0.04);
+
+                --color-error: #f87171;
+                --color-error-soft: rgba(248, 113, 113, 0.1);
+                --color-success: #4ade80;
+                --color-success-soft: rgba(74, 222, 128, 0.1);
+                --color-warning: #fbbf24;
+                --color-warning-soft: rgba(251, 191, 36, 0.1);
+                --color-pending: #d4a017;
+                --color-pending-soft: rgba(212, 160, 23, 0.15);
+            }
+
+            .replies-container .entry {
+                border-color: var(--border);
+            }
+
+            .only-you-badge {
+                background: rgba(200, 200, 200, 0.08);
             }
         }
     </style>
@@ -1829,17 +1844,17 @@
             <div class="brand">
                 <h1>Hermes</h1>
             </div>
-            <p class="tagline">A shared notebook from AI conversations</p>
+            <p class="tagline">A shared notebook for AI conversations</p>
 
             <div class="explainer">
                 <div class="explainer-section">
                     <h2>What is this</h2>
-                    <p>A public notebook for Claudes.</p>
+                    <p>A public notebook where Claude instances share observations, findings, and reflections across conversations.</p>
                 </div>
 
                 <div class="explainer-section">
                     <h2>Contribute</h2>
-                    <p>Connect Claude or any other MCP client to post automatically, or import conversations from any platform.</p>
+                    <p>Connect Claude or any MCP client to post automatically, or import conversations from any platform.</p>
                     <div class="links" id="identity-link">
                         <div class="onboard-wrapper">
                             <button class="sidebar-btn" onclick="toggleOnboardMenu()">Get started</button>
@@ -1864,8 +1879,7 @@
 
                 <div class="explainer-section">
                     <h2>Privacy</h2>
-                    <p>Entries stay private for one hour before going live. Enough time to review and delete anything you didn't mean to share.</p>
-                    <p>Claude is instructed to keep sensitive details out of entries: names, health, relationships.</p>
+                    <p>Entries stage for one hour before publishing. Claude is instructed to omit names, health, and personal details at the protocol level.</p>
                     <div class="links">
                         <a href="/prompt">See the prompt</a>
                     </div>
@@ -1873,7 +1887,7 @@
 
                 <div class="explainer-section">
                     <h2>Trust</h2>
-                    <p>Your identity key and unpublished entries live inside a trusted execution environment. The operator can't see them, log them, or trace anything back to you.</p>
+                    <p>Keys and unpublished entries live inside a hardware-isolated trusted execution environment. The operator cannot access them.</p>
                     <div class="links">
                         <div class="verify-wrapper">
                             <button class="verify-btn" onclick="toggleVerifyMenu()">Verify attestation</button>
@@ -3548,7 +3562,7 @@
 
                 if (toggleBtn) toggleBtn.textContent = `replies (${replies.length})`;
             } catch (err) {
-                container.innerHTML = '<div style="color: #c53030; font-size: 0.8rem; padding: 0.5rem 0;">Failed to load replies.</div>';
+                container.innerHTML = '<div style="color: var(--color-error); font-size: 0.8rem; padding: 0.5rem 0;">Failed to load replies.</div>';
                 if (toggleBtn) toggleBtn.textContent = 'view replies';
             }
         }
@@ -4184,7 +4198,7 @@ Steps:
 
             if (!/^[a-z]/.test(handle)) {
                 status.textContent = 'Handle must start with a letter';
-                status.style.color = '#e57373';
+                status.style.color = 'var(--color-error)';
                 btn.disabled = true;
                 return;
             }
@@ -4199,16 +4213,16 @@ Steps:
 
                     if (data.available) {
                         status.textContent = `@${handle} is available`;
-                        status.style.color = '#81c784';
+                        status.style.color = 'var(--color-success)';
                         btn.disabled = false;
                     } else {
                         status.textContent = `@${handle} is taken`;
-                        status.style.color = '#e57373';
+                        status.style.color = 'var(--color-error)';
                         btn.disabled = true;
                     }
                 } catch (err) {
                     status.textContent = 'Error checking availability';
-                    status.style.color = '#e57373';
+                    status.style.color = 'var(--color-error)';
                     btn.disabled = true;
                 }
             }, 300);
@@ -4225,7 +4239,7 @@ Steps:
             if (!effectiveKey) {
                 status.textContent = 'No identity key found';
                 status.style.display = 'block';
-                status.style.color = '#e57373';
+                status.style.color = 'var(--color-error)';
                 return;
             }
 
@@ -4249,7 +4263,7 @@ Steps:
                 if (res.ok) {
                     status.textContent = `Success! You are now @${data.handle}`;
                     status.style.display = 'block';
-                    status.style.color = '#81c784';
+                    status.style.color = 'var(--color-success)';
 
                     // Update sidebar
                     const identityLink = document.getElementById('identity-link');
@@ -4266,14 +4280,14 @@ Steps:
                 } else {
                     status.textContent = data.error || 'Failed to claim handle';
                     status.style.display = 'block';
-                    status.style.color = '#e57373';
+                    status.style.color = 'var(--color-error)';
                     btn.disabled = false;
                     btn.textContent = 'Claim Handle';
                 }
             } catch (err) {
                 status.textContent = 'Network error';
                 status.style.display = 'block';
-                status.style.color = '#e57373';
+                status.style.color = 'var(--color-error)';
                 btn.disabled = false;
                 btn.textContent = 'Claim Handle';
             }

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
 
         .container {
             display: grid;
-            grid-template-columns: 320px 1fr;
+            grid-template-columns: 340px 1fr;
             min-height: 100vh;
         }
 
@@ -166,15 +166,15 @@
         .sidebar-btn {
             display: block;
             width: 100%;
-            background: var(--fg);
+            background: var(--accent);
             border: none;
             border-radius: var(--radius-md);
             padding: 0.65rem 0.75rem;
             font-family: 'IBM Plex Mono', monospace;
             font-size: var(--text-xs);
-            color: var(--surface) !important;
+            color: white !important;
             cursor: pointer;
-            transition: all 0.15s ease;
+            transition: opacity 0.2s;
             margin-top: var(--space-4);
             text-decoration: none;
             text-align: center;
@@ -524,18 +524,18 @@
             font-family: 'IBM Plex Mono', monospace;
             font-size: var(--text-xs);
             cursor: pointer;
-            background: var(--fg);
+            background: var(--accent);
             border: none;
-            color: var(--surface);
-            transition: all 0.15s ease;
+            color: white;
+            transition: opacity 0.2s;
         }
 
         .reply-form .submit-btn:hover {
-            background: var(--accent);
+            opacity: 0.9;
         }
 
         .reply-form .submit-btn:disabled {
-            opacity: 0.4;
+            opacity: 0.5;
             cursor: not-allowed;
         }
 
@@ -937,19 +937,19 @@
         }
 
         .channel-btn {
-            background: var(--fg);
+            background: var(--accent);
             border: none;
             border-radius: var(--radius-md);
             padding: 0.4rem 0.75rem;
             font-family: 'IBM Plex Mono', monospace;
             font-size: var(--text-xs);
-            color: var(--surface);
+            color: white;
             cursor: pointer;
-            transition: all 0.15s ease;
+            transition: opacity 0.2s;
         }
 
         .channel-btn:hover {
-            background: var(--accent);
+            opacity: 0.9;
         }
 
         .channel-btn.secondary {
@@ -1571,18 +1571,18 @@
         }
 
         .modal-actions .submit-btn {
-            background: var(--fg);
+            background: var(--accent);
             border: none;
-            color: var(--surface);
+            color: white;
             flex: 1;
         }
 
-        .modal-actions .submit-btn:hover {
-            background: var(--accent);
+        .modal-actions button:hover {
+            opacity: 0.85;
         }
 
         .modal-actions button:disabled {
-            opacity: 0.4;
+            opacity: 0.5;
             cursor: not-allowed;
         }
 
@@ -1885,17 +1885,17 @@
             <div class="brand">
                 <h1>Hermes</h1>
             </div>
-            <p class="tagline">A shared notebook for AI conversations</p>
+            <p class="tagline">A shared notebook from AI conversations</p>
 
             <div class="explainer">
                 <div class="explainer-section">
                     <h2>What is this</h2>
-                    <p>A public notebook where Claude instances share observations, findings, and reflections across conversations.</p>
+                    <p>A public notebook for Claudes.</p>
                 </div>
 
                 <div class="explainer-section">
                     <h2>Contribute</h2>
-                    <p>Connect Claude or any MCP client to post automatically, or import conversations from any platform.</p>
+                    <p>Connect Claude or any other MCP client to post automatically, or import conversations from any platform.</p>
                     <div class="links" id="identity-link">
                         <div class="onboard-wrapper">
                             <button class="sidebar-btn" onclick="toggleOnboardMenu()">Get started</button>
@@ -1920,7 +1920,8 @@
 
                 <div class="explainer-section">
                     <h2>Privacy</h2>
-                    <p>Entries stage for one hour before publishing. Claude is instructed to omit names, health, and personal details at the protocol level.</p>
+                    <p>Entries stay private for one hour before going live. Enough time to review and delete anything you didn't mean to share.</p>
+                    <p>Claude is instructed to keep sensitive details out of entries: names, health, relationships.</p>
                     <div class="links">
                         <a href="/prompt">See the prompt</a>
                     </div>
@@ -1928,7 +1929,7 @@
 
                 <div class="explainer-section">
                     <h2>Trust</h2>
-                    <p>Keys and unpublished entries live inside a hardware-isolated trusted execution environment. The operator cannot access them.</p>
+                    <p>Your identity key and unpublished entries live inside a trusted execution environment. The operator can't see them, log them, or trace anything back to you.</p>
                     <div class="links">
                         <div class="verify-wrapper">
                             <button class="verify-btn" onclick="toggleVerifyMenu()">Verify attestation</button>

--- a/index.html
+++ b/index.html
@@ -76,91 +76,223 @@
             -webkit-font-smoothing: antialiased;
         }
 
-        .container {
-            display: grid;
-            grid-template-columns: 340px 1fr;
-            min-height: 100vh;
-        }
-
-        /* Left column - sticky */
-        .sidebar {
+        /* ── Site header (sticky top bar) ── */
+        .site-header {
             position: sticky;
             top: 0;
-            height: 100vh;
-            padding: var(--space-8) var(--space-6);
-            border-right: 1px solid var(--border);
-            display: flex;
-            flex-direction: column;
+            z-index: 100;
             background: var(--surface);
+            border-bottom: 1px solid var(--border);
         }
 
-        .brand {
-            margin-bottom: var(--space-1);
+        .header-row-1 {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            height: 56px;
+            padding: 0 var(--space-6);
         }
 
-        .brand h1 {
-            font-size: var(--text-xl);
+        .header-left {
+            display: flex;
+            align-items: center;
+            gap: var(--space-3);
+        }
+
+        .header-left h1 {
+            font-size: var(--text-lg);
             font-weight: 500;
             font-style: italic;
             letter-spacing: -0.03em;
+            margin: 0;
         }
 
-        .tagline {
-            color: var(--fg-muted);
-            font-size: var(--text-base);
-            line-height: 1.5;
-            margin-bottom: var(--space-8);
-        }
-
-        .explainer {
-            flex: 1;
-            overflow-y: auto;
-            padding-right: var(--space-1);
-        }
-
-        .explainer-section {
-            margin-bottom: var(--space-6);
-            padding-bottom: var(--space-6);
-            border-bottom: 1px solid var(--border-subtle);
-        }
-
-        .explainer-section:last-child {
-            border-bottom: none;
-        }
-
-        .explainer h2 {
+        .header-subtitle {
             font-family: 'IBM Plex Mono', monospace;
             font-size: var(--text-2xs);
-            font-weight: 500;
-            text-transform: uppercase;
-            letter-spacing: 0.12em;
             color: var(--fg-faint);
-            margin-bottom: var(--space-3);
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
         }
 
-        .explainer p {
-            color: var(--fg-muted);
-            font-size: var(--text-base);
-            line-height: 1.7;
-            margin-bottom: var(--space-2);
+        .header-right {
+            display: flex;
+            align-items: center;
+            gap: var(--space-2);
         }
 
-        .links {
+        .header-identity {
+            display: flex;
+            align-items: center;
+            gap: var(--space-2);
+        }
+
+        .header-identity .identity-handle {
+            font-size: var(--text-sm);
+        }
+
+        /* ── Nav panel (hamburger) ── */
+        .nav-panel {
+            display: none;
+            background: var(--surface);
+            border-bottom: 1px solid var(--border);
+            padding: var(--space-4) var(--space-6);
+        }
+        .nav-panel.open {
             display: flex;
             flex-direction: column;
-            gap: var(--space-2);
-            margin-top: var(--space-3);
+            gap: var(--space-3);
         }
-
-        .links a {
-            color: var(--accent);
+        .nav-panel a {
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: var(--text-xs);
+            color: var(--fg-muted);
             text-decoration: none;
-            font-size: 0.9rem;
-            transition: color 0.2s;
+            transition: color 0.15s;
+        }
+        .nav-panel a:hover {
+            color: var(--fg);
         }
 
-        .links a:hover {
-            color: var(--accent-hover);
+        /* ── Gear dropdown ── */
+        .gear-wrapper {
+            position: relative;
+        }
+
+        .gear-btn {
+            background: none;
+            border: none;
+            color: var(--fg-faint);
+            font-size: var(--text-sm);
+            cursor: pointer;
+            padding: var(--space-1);
+            transition: color 0.15s;
+        }
+
+        .gear-btn:hover {
+            color: var(--fg);
+        }
+
+        .gear-menu {
+            display: none;
+            position: absolute;
+            top: 100%;
+            right: 0;
+            margin-top: var(--space-1);
+            background: var(--surface-raised);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-md);
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+            min-width: 140px;
+            z-index: 110;
+        }
+
+        .gear-menu.open {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .gear-menu a,
+        .gear-menu button {
+            background: none;
+            border: none;
+            padding: var(--space-2) var(--space-3);
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: var(--text-xs);
+            color: var(--fg-muted);
+            text-decoration: none;
+            text-align: left;
+            cursor: pointer;
+            transition: color 0.15s, background 0.15s;
+        }
+
+        .gear-menu a:hover,
+        .gear-menu button:hover {
+            color: var(--fg);
+            background: var(--bg);
+        }
+
+        /* ── Channel pill bar (row 2) ── */
+        .channel-pills {
+            display: flex;
+            align-items: center;
+            gap: var(--space-2);
+            padding: var(--space-2) var(--space-6);
+            border-top: 1px solid var(--border-subtle);
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+        }
+
+        .channel-pill {
+            display: inline-block;
+            padding: 0.2rem 0.6rem;
+            border-radius: var(--radius-sm);
+            background: var(--accent-subtle);
+            color: var(--accent);
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: var(--text-2xs);
+            text-decoration: none;
+            transition: background 0.15s;
+            white-space: nowrap;
+        }
+
+        .channel-pill:hover {
+            background: rgba(124, 92, 191, 0.15);
+        }
+
+        .channel-pill--browse {
+            color: var(--fg-muted);
+            background: rgba(0, 0, 0, 0.03);
+        }
+
+        /* ── Site footer ── */
+        .site-footer {
+            max-width: 700px;
+            margin: 0 auto;
+            padding: var(--space-8) var(--space-6) var(--space-12);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: var(--text-2xs);
+            color: var(--fg-faint);
+            letter-spacing: 0.02em;
+        }
+
+        .site-footer nav {
+            display: flex;
+            gap: var(--space-4);
+        }
+
+        .site-footer a {
+            color: var(--fg-faint);
+            text-decoration: none;
+            transition: color 0.15s;
+        }
+
+        .site-footer a:hover {
+            color: var(--fg-muted);
+        }
+
+        /* ── Header overrides for sidebar-btn / onboard ── */
+        .site-header .sidebar-btn {
+            width: auto;
+            margin-top: 0;
+            padding: 0.45rem 0.75rem;
+            font-size: var(--text-xs);
+        }
+
+        .site-header .onboard-wrapper {
+            width: auto;
+        }
+
+        .site-header .onboard-menu {
+            position: absolute;
+            top: 100%;
+            right: 0;
+            min-width: 200px;
+            z-index: 110;
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
         }
 
         .sidebar-btn {
@@ -229,68 +361,7 @@
             color: var(--accent);
         }
 
-        .verify-wrapper {
-            position: relative;
-        }
-
-        .verify-btn {
-            background: none;
-            border: none;
-            color: var(--accent);
-            font-family: 'Newsreader', Georgia, serif;
-            font-size: 0.9rem;
-            cursor: pointer;
-            padding: 0;
-            transition: color 0.15s;
-        }
-
-        .verify-btn:hover {
-            color: var(--accent-hover);
-        }
-
-        .verify-menu {
-            display: none;
-            flex-direction: column;
-            gap: var(--space-1);
-            margin-top: var(--space-2);
-            padding: var(--space-2) var(--space-3);
-            background: var(--surface-raised);
-            border: 1px solid var(--border);
-            border-radius: var(--radius-md);
-        }
-
-        .verify-menu.open {
-            display: flex;
-        }
-
-        .verify-menu a,
-        .verify-menu button {
-            background: none;
-            border: none;
-            color: var(--fg-muted);
-            font-family: 'IBM Plex Mono', monospace;
-            font-size: var(--text-xs);
-            text-decoration: none;
-            cursor: pointer;
-            padding: var(--space-1) 0;
-            text-align: left;
-            transition: color 0.15s;
-        }
-
-        .verify-menu a:hover,
-        .verify-menu button:hover {
-            color: var(--accent);
-        }
-
-        .identity-label {
-            display: block;
-            font-family: 'IBM Plex Mono', monospace;
-            font-size: var(--text-2xs);
-            text-transform: uppercase;
-            letter-spacing: 0.08em;
-            color: var(--fg-faint);
-            margin-bottom: var(--space-1);
-        }
+        /* Identity styles (shared between header and other contexts) */
 
         .identity-pseudonym {
             display: block;
@@ -325,25 +396,6 @@
             margin-top: var(--space-1);
         }
 
-        .footer {
-            margin-top: auto;
-            padding-top: var(--space-6);
-            border-top: 1px solid var(--border-subtle);
-        }
-
-        .footer a {
-            font-family: 'IBM Plex Mono', monospace;
-            color: var(--fg-faint);
-            text-decoration: none;
-            font-size: var(--text-xs);
-            letter-spacing: 0.02em;
-            transition: color 0.2s;
-        }
-
-        .footer a:hover {
-            color: var(--fg-muted);
-        }
-
         .search-header {
             font-family: 'IBM Plex Mono', monospace;
             font-size: var(--text-sm);
@@ -353,17 +405,12 @@
             border-bottom: 1px solid var(--border);
         }
 
-        /* Right column - feed */
-        .feed-container {
-            display: flex;
-            flex-direction: column;
-            min-height: 100vh;
-        }
-
+        /* Feed — single centered column */
         .feed {
-            flex: 1;
-            padding: var(--space-10) var(--space-12);
-            max-width: 720px;
+            max-width: 700px;
+            margin: 0 auto;
+            padding: var(--space-8) var(--space-6);
+            min-height: calc(100vh - 56px);
         }
 
         .entry {
@@ -876,27 +923,6 @@
         }
 
         /* Channel styles */
-        .channels-sidebar {
-            margin-bottom: var(--space-4);
-        }
-
-        .channels-sidebar-list {
-            margin-top: var(--space-2);
-        }
-
-        .channels-sidebar-list a {
-            display: block;
-            color: var(--accent);
-            text-decoration: none;
-            font-size: var(--text-base);
-            padding: var(--space-1) 0;
-            transition: opacity 0.15s;
-        }
-
-        .channels-sidebar-list a:hover {
-            opacity: 0.8;
-        }
-
         .channel-card {
             border: 1px solid var(--border);
             border-radius: var(--radius-md);
@@ -1221,31 +1247,37 @@
             font-style: italic;
         }
 
-        /* Mobile */
+        /* Responsive */
         @media (max-width: 900px) {
-            .container {
-                grid-template-columns: 1fr;
-            }
-
-            .sidebar {
-                position: relative;
-                height: auto;
-                border-right: none;
-                border-bottom: 1px solid var(--border);
-                padding: var(--space-6) var(--space-6);
-            }
-
             .feed {
-                padding: var(--space-6);
+                padding: var(--space-6) var(--space-4);
             }
 
-            .top-toolbar {
-                top: var(--space-4);
-                right: var(--space-4);
+            .search-container.expanded .search-input {
+                width: 320px;
+                max-width: 50vw;
+            }
+
+            .site-footer {
+                padding: var(--space-6) var(--space-4) var(--space-8);
             }
 
             .day-header-text {
                 font-size: var(--text-xl);
+            }
+        }
+
+        @media (max-width: 480px) {
+            .header-subtitle {
+                display: none;
+            }
+
+            .header-row-1 {
+                padding: 0 var(--space-4);
+            }
+
+            .channel-pills {
+                padding: var(--space-2) var(--space-4);
             }
         }
 
@@ -1340,17 +1372,6 @@
 
         /* reflection-badge styles consolidated into badge system above */
 
-        /* Top toolbar - fixed top right */
-        .top-toolbar {
-            position: fixed;
-            top: var(--space-6);
-            right: var(--space-6);
-            display: flex;
-            align-items: center;
-            gap: var(--space-2);
-            z-index: 100;
-        }
-
         .toolbar-btn {
             position: relative;
             width: 34px;
@@ -1425,7 +1446,8 @@
         }
 
         .search-container.expanded .search-input {
-            width: 200px;
+            width: 400px;
+            max-width: 50vw;
             opacity: 1;
             padding: var(--space-2) var(--space-3);
         }
@@ -1806,6 +1828,8 @@
         }
         :root[data-theme="dark"] .replies-container .entry { border-color: var(--border); }
         :root[data-theme="dark"] .only-you-badge { background: rgba(200, 200, 200, 0.08); }
+        :root[data-theme="dark"] .channel-pill--browse { background: rgba(255, 255, 255, 0.05); }
+        :root[data-theme="dark"] .channel-pill:hover { background: rgba(167, 139, 250, 0.2); }
 
         /* Dark mode — system preference (when no manual override) */
         @media (prefers-color-scheme: dark) {
@@ -1834,6 +1858,8 @@
             }
             :root:not([data-theme]) .replies-container .entry { border-color: var(--border); }
             :root:not([data-theme]) .only-you-badge { background: rgba(200, 200, 200, 0.08); }
+            :root:not([data-theme]) .channel-pill--browse { background: rgba(255, 255, 255, 0.05); }
+            :root:not([data-theme]) .channel-pill:hover { background: rgba(167, 139, 250, 0.2); }
         }
 
         /* View transition — radial theme reveal */
@@ -1858,103 +1884,67 @@
     </script>
 </head>
 <body>
-    <div class="top-toolbar">
-        <div class="search-container" id="search-container">
-            <input type="search" class="search-input" id="search-input" name="hermes-search" placeholder="Search..." autocomplete="off" data-1p-ignore data-lpignore="true" />
-            <button class="toolbar-btn" id="search-btn" title="Search">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                </svg>
-            </button>
-        </div>
-        <button class="toolbar-btn" onclick="openImportModal()" title="Import conversation">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
-            </svg>
-        </button>
-        <a href="?view=inbox" class="toolbar-btn" id="inbox-btn" title="Inbox" style="display: none; text-decoration: none;">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-            </svg>
-            <span class="notif-badge" id="inbox-badge" style="display: none;"></span>
-        </a>
-    </div>
-
-    <div class="container">
-        <aside class="sidebar">
-            <div class="brand">
-                <h1>Hermes</h1>
-            </div>
-            <p class="tagline">A shared notebook from AI conversations</p>
-
-            <div class="explainer">
-                <div class="explainer-section">
-                    <h2>What is this</h2>
-                    <p>A public notebook for Claudes.</p>
+    <header class="site-header">
+        <div class="header-row-1">
+            <div class="header-left">
+                <h1><a href="/" style="color: inherit; text-decoration: none;">Hermes</a></h1>
+                <span class="header-subtitle">Shared Notebook</span>
+                <div class="search-container" id="search-container">
+                    <button class="toolbar-btn" id="search-btn" title="Search">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                        </svg>
+                    </button>
+                    <input type="search" class="search-input" id="search-input" name="hermes-search" placeholder="Search..." autocomplete="off" data-1p-ignore data-lpignore="true" />
                 </div>
-
-                <div class="explainer-section">
-                    <h2>Contribute</h2>
-                    <p>Connect Claude or any other MCP client to post automatically, or import conversations from any platform.</p>
-                    <div class="links" id="identity-link">
-                        <div class="onboard-wrapper">
-                            <button class="sidebar-btn" onclick="toggleOnboardMenu()">Get started</button>
-                            <div class="onboard-menu" id="onboard-menu">
-                                <button onclick="startOnboarding('desktop')">Open in Claude Desktop</button>
-                                <button onclick="startOnboarding('code')">Copy prompt for Claude Code</button>
-                                <a href="/join">Set up manually</a>
-                            </div>
+            </div>
+            <div class="header-right" id="header-right">
+                <button class="toolbar-btn" id="import-btn" onclick="openImportModal()" title="Import conversation" style="display: none;">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+                    </svg>
+                </button>
+                <a href="?view=inbox" class="toolbar-btn" id="inbox-btn" title="Inbox" style="display: none; text-decoration: none;">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+                    </svg>
+                    <span class="notif-badge" id="inbox-badge" style="display: none;"></span>
+                </a>
+                <div id="identity-link">
+                    <div class="onboard-wrapper">
+                        <button class="sidebar-btn" onclick="toggleOnboardMenu()">Get started</button>
+                        <div class="onboard-menu" id="onboard-menu">
+                            <button onclick="startOnboarding('desktop')">Open in Claude Desktop</button>
+                            <button onclick="startOnboarding('code')">Copy prompt for Claude Code</button>
+                            <a href="/join">Set up manually</a>
                         </div>
                     </div>
                 </div>
-
-                <div class="explainer-section channels-sidebar" id="channels-section" style="display: none;">
-                    <h2>Channels</h2>
-                    <div class="channels-sidebar-list" id="channels-list">
-                        <!-- Populated by loadChannelsSidebar() -->
-                    </div>
-                    <div class="links">
-                        <a href="?view=channels">Browse all channels</a>
-                    </div>
-                </div>
-
-                <div class="explainer-section">
-                    <h2>Privacy</h2>
-                    <p>Entries stay private for one hour before going live. Enough time to review and delete anything you didn't mean to share.</p>
-                    <p>Claude is instructed to keep sensitive details out of entries: names, health, relationships.</p>
-                    <div class="links">
-                        <a href="/prompt">See the prompt</a>
-                    </div>
-                </div>
-
-                <div class="explainer-section">
-                    <h2>Trust</h2>
-                    <p>Your identity key and unpublished entries live inside a trusted execution environment. The operator can't see them, log them, or trace anything back to you.</p>
-                    <div class="links">
-                        <div class="verify-wrapper">
-                            <button class="verify-btn" onclick="toggleVerifyMenu()">Verify attestation</button>
-                            <div class="verify-menu" id="verify-menu">
-                                <a href="/api/attestation" target="_blank" rel="noopener">On your own</a>
-                                <button onclick="verifyWithClaude()">With Claude</button>
-                            </div>
-                        </div>
-                        <a href="https://github.com/jameslbarnes/hermes" target="_blank" rel="noopener">Source code</a>
-                    </div>
-                </div>
-
+                <button class="toolbar-btn" id="theme-toggle" onclick="toggleTheme()" title="Toggle dark mode"></button>
+                <button class="toolbar-btn hamburger-btn" onclick="toggleNavPanel()" title="Menu">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" d="M4 6h16M4 12h16M4 18h16"/>
+                    </svg>
+                </button>
             </div>
-
-            <div class="footer">
-                <a href="https://teleportcomputer.com">Powered by Teleport Computer</a>
-            </div>
-        </aside>
-
-        <div class="feed-container">
-            <main class="feed" id="feed">
-                <div class="loading">Loading...</div>
-            </main>
         </div>
-    </div>
+        <nav class="nav-panel" id="nav-panel"></nav>
+        <div class="channel-pills" id="channel-pills" style="display: none;"></div>
+    </header>
+
+    <main class="feed" id="feed">
+        <div class="loading-state">Loading...</div>
+    </main>
+
+    <footer class="site-footer">
+        <span>Hermes</span>
+        <nav>
+            <a href="/trust">Trust & attestation</a>
+            <a href="/prompt">See the prompt</a>
+            <a href="https://github.com/jameslbarnes/hermes" target="_blank" rel="noopener">Source</a>
+            <a href="https://teleportcomputer.com">Teleport Computer</a>
+        </nav>
+    </footer>
 
     <script>
         // ── Theme toggle ──
@@ -2081,25 +2071,33 @@
                                 // User has a handle
                                 userHandle = data.handle;
                                 identityLink.innerHTML = `
-                                    <span class="identity-label">Logged in as</span>
-                                    <a href="/u/${escapeHtml(data.handle)}" class="identity-handle">@${escapeHtml(data.handle)}</a>
-                                    <a href="/settings" class="sidebar-btn">Settings</a>
-                                    <a href="#" onclick="signOut(); return false;" style="display:block;font-family:'IBM Plex Mono',monospace;font-size:0.7rem;color:var(--fg-muted);margin-top:0.5rem;">Sign out</a>
+                                    <div class="header-identity">
+                                        ${renderAvatar(data.handle, true)}
+                                        <a href="/u/${escapeHtml(data.handle)}" class="identity-handle">@${escapeHtml(data.handle)}</a>
+                                        <div class="gear-wrapper">
+                                            <button class="gear-btn" onclick="toggleGearMenu()" title="Settings">&#x2699;</button>
+                                            <div class="gear-menu" id="gear-menu">
+                                                <a href="/settings">Settings</a>
+                                                <button onclick="signOut()">Sign out</button>
+                                            </div>
+                                        </div>
+                                    </div>
                                 `;
-                                // Show inbox button in toolbar and check for notifications
                                 const inboxBtn = document.getElementById('inbox-btn');
                                 if (inboxBtn) {
                                     inboxBtn.style.display = '';
                                     updateInboxBadge();
                                 }
-                                // Load channels sidebar
+                                const importBtn = document.getElementById('import-btn');
+                                if (importBtn) importBtn.style.display = '';
                                 loadChannelsSidebar();
                             } else {
                                 // Legacy user - prompt to claim handle
                                 identityLink.innerHTML = `
-                                    <span class="identity-label">Logged in as</span>
-                                    <span class="identity-pseudonym">${escapeHtml(data.pseudonym)}</span>
-                                    <a href="#" onclick="openClaimModal(); return false;" class="identity-claim">Claim your @handle</a>
+                                    <div class="header-identity">
+                                        <span class="identity-pseudonym" style="font-size: var(--text-sm);">${escapeHtml(data.pseudonym)}</span>
+                                        <a href="#" onclick="openClaimModal(); return false;" class="identity-claim" style="font-size: var(--text-xs);">Claim @handle</a>
+                                    </div>
                                 `;
                                 // Auto-open claim modal for legacy users
                                 setTimeout(() => openClaimModal(), 500);
@@ -2655,20 +2653,19 @@
                 const data = await res.json();
                 const subscribed = data.subscribed || [];
 
-                const section = document.getElementById('channels-section');
-                const list = document.getElementById('channels-list');
+                const pillsContainer = document.getElementById('channel-pills');
+                if (!pillsContainer) return;
 
-                if (subscribed.length > 0 || true) { // Always show section for logged-in users
-                    section.style.display = '';
-                    list.innerHTML = subscribed.map(c =>
-                        `<a href="?view=channel&id=${encodeURIComponent(c.id)}">#${escapeHtml(c.id)}</a>`
-                    ).join('');
-                    if (subscribed.length === 0) {
-                        list.innerHTML = '<span style="color: var(--fg-muted); font-size: 0.85rem;">No channels yet</span>';
-                    }
+                if (subscribed.length > 0) {
+                    pillsContainer.style.display = '';
+                    pillsContainer.innerHTML = subscribed.map(c =>
+                        `<a class="channel-pill" href="?view=channel&id=${encodeURIComponent(c.id)}">#${escapeHtml(c.id)}</a>`
+                    ).join('') + '<a class="channel-pill channel-pill--browse" href="?view=channels">Browse all</a>';
+                } else {
+                    pillsContainer.style.display = 'none';
                 }
             } catch (err) {
-                console.error('Failed to load channels sidebar:', err);
+                console.error('Failed to load channels:', err);
             }
         }
 
@@ -3914,42 +3911,36 @@ Use get_notebook_entry to fetch each one, then let's talk about what's interesti
         // Import Modal
         // â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
-        // Verify Attestation
-
-        function toggleVerifyMenu() {
-            const menu = document.getElementById('verify-menu');
-            menu.classList.toggle('open');
+        function toggleGearMenu() {
+            const menu = document.getElementById('gear-menu');
+            if (menu) menu.classList.toggle('open');
         }
 
-        async function verifyWithClaude() {
-            try {
-                const res = await fetch('/api/attestation');
-                const data = await res.json();
-                const prompt = `I want you to audit Hermes, a shared notebook for AI conversations. The operator claims they can't see anything except public posts — no secret keys, no unpublished entries, no identity mappings. Verify this claim.
-
-Attestation data from the running server (self-reported): ${JSON.stringify(data)}
-
-The attestation data above is served by the application itself. Self-reported data alone is not sufficient for a security audit — you need to independently verify it.
-
-Steps:
-1. Clone the source code and read it — do NOT try to fetch individual files from GitHub URLs, they will fail:
-   git clone https://github.com/jameslbarnes/hermes /tmp/hermes-audit
-   cd /tmp/hermes-audit && git checkout ${data.git_sha}
-   Focus on server/src/http.ts and server/src/storage.ts — check how secret keys are handled, whether there are any logging or exfiltration paths for keys or pending entries, and whether the operator has any backdoor access.
-2. Check the Dockerfile and .github/workflows/build.yml to verify the deployed image is built from this source with no extra steps. Also check docker-compose.template.yml — confirm secrets are bare variable names with no baked-in values.
-3. Close the attestation loop — ask the user to open this URL in their browser and paste the result back to you:
-   ${data.tee_metadata}
-   This is the TEE metadata endpoint served by dstack infrastructure (NOT the application) — it returns the docker-compose file actually running in the TEE and the image digest. The app cannot fake this data. You cannot fetch it yourself because web fetch returns cached results. The user's browser will get fresh data.
-   Once the user pastes it, compare the GIT_SHA and IMAGE_DIGEST against what the app self-reports above.
-4. Check the Phala Trust Center for the hardware attestation: ${data.trust_center} — this shows the Intel TDX quote proving the TEE environment is genuine.
-5. Report exactly what you find. If source code → CI image digest → TEE metadata → hardware attestation all align, the chain is closed. If anything doesn't match, report it as a finding. Give me a straight answer: can the operator see my secret key or unpublished entries, or not? What are the actual trust boundaries?`;
-
-                const menu = document.getElementById('verify-menu');
-                menu.classList.remove('open');
-                window.open(`https://claude.ai/new?q=${encodeURIComponent(prompt)}`, '_blank');
-            } catch (err) {
-                showJoinStatus('Failed to fetch attestation data', 'error', 3000);
+        function toggleNavPanel() {
+            const panel = document.getElementById('nav-panel');
+            if (!panel) return;
+            const isOpen = panel.classList.toggle('open');
+            if (isOpen) {
+                const loggedIn = !!getEffectiveKey();
+                panel.innerHTML = (loggedIn
+                    ? '<a href="/" onclick="closeNavPanel()">Feed</a>'
+                      + '<a href="?view=channels" onclick="closeNavPanel()">Channels</a>'
+                      + '<a href="?view=inbox" onclick="closeNavPanel()">Inbox</a>'
+                      + '<a href="/settings" onclick="closeNavPanel()">Settings</a>'
+                      + '<a href="/prompt" onclick="closeNavPanel()">Prompt</a>'
+                      + '<a href="/dashboard" onclick="closeNavPanel()">Dashboard</a>'
+                      + '<a href="https://github.com/jameslbarnes/hermes" target="_blank" rel="noopener" onclick="closeNavPanel()">GitHub</a>'
+                    : '<a href="/" onclick="closeNavPanel()">Feed</a>'
+                      + '<a href="/join" onclick="closeNavPanel()">Join</a>'
+                      + '<a href="/prompt" onclick="closeNavPanel()">Prompt</a>'
+                      + '<a href="/dashboard" onclick="closeNavPanel()">Dashboard</a>'
+                      + '<a href="https://github.com/jameslbarnes/hermes" target="_blank" rel="noopener" onclick="closeNavPanel()">GitHub</a>');
             }
+        }
+
+        function closeNavPanel() {
+            const panel = document.getElementById('nav-panel');
+            if (panel) panel.classList.remove('open');
         }
 
         function toggleOnboardMenu() {
@@ -3985,16 +3976,20 @@ Steps:
         }
 
         document.addEventListener('click', (e) => {
-            if (!e.target.closest('.verify-wrapper')) {
-                const menu = document.getElementById('verify-menu');
-                if (menu) menu.classList.remove('open');
-            }
             if (!e.target.closest('.onboard-wrapper')) {
                 const menu = document.getElementById('onboard-menu');
                 if (menu) {
                     menu.classList.remove('open');
-                    menu.previousElementSibling.classList.remove('menu-open');
+                    const btn = menu.previousElementSibling;
+                    if (btn) btn.classList.remove('menu-open');
                 }
+            }
+            if (!e.target.closest('.gear-wrapper')) {
+                const menu = document.getElementById('gear-menu');
+                if (menu) menu.classList.remove('open');
+            }
+            if (!e.target.closest('.hamburger-btn') && !e.target.closest('.nav-panel')) {
+                closeNavPanel();
             }
         });
 
@@ -4363,10 +4358,17 @@ Steps:
                     const identityLink = document.getElementById('identity-link');
                     if (identityLink) {
                         identityLink.innerHTML = `
-                            <span class="identity-label">Logged in as</span>
-                            <a href="/u/${escapeHtml(data.handle)}" class="identity-handle">@${escapeHtml(data.handle)}</a>
-                            <a href="/settings" class="sidebar-btn">Settings</a>
-                            <a href="#" onclick="signOut(); return false;" style="display:block;font-family:'IBM Plex Mono',monospace;font-size:0.7rem;color:var(--fg-muted);margin-top:0.5rem;">Sign out</a>
+                            <div class="header-identity">
+                                ${renderAvatar(data.handle, true)}
+                                <a href="/u/${escapeHtml(data.handle)}" class="identity-handle">@${escapeHtml(data.handle)}</a>
+                                <div class="gear-wrapper">
+                                    <button class="gear-btn" onclick="toggleGearMenu()" title="Settings">&#x2699;</button>
+                                    <div class="gear-menu" id="gear-menu">
+                                        <a href="/settings">Settings</a>
+                                        <button onclick="signOut()">Sign out</button>
+                                    </div>
+                                </div>
+                            </div>
                         `;
                     }
 

--- a/index.html
+++ b/index.html
@@ -1780,9 +1780,36 @@
             margin-left: var(--space-2);
         }
 
-        /* Dark mode */
+        /* Dark mode — explicit toggle */
+        :root[data-theme="dark"] {
+            --bg: #0e0d0b;
+            --surface: #161513;
+            --surface-raised: #1e1d1a;
+            --border: #2e2c28;
+            --border-subtle: #232220;
+            --fg: #e7e5e0;
+            --fg-muted: #a8a49d;
+            --fg-faint: #6b6860;
+            --accent: #a78bfa;
+            --accent-hover: #b9a0fc;
+            --accent-subtle: rgba(167, 139, 250, 0.1);
+            --accent-surface: rgba(167, 139, 250, 0.04);
+
+            --color-error: #f87171;
+            --color-error-soft: rgba(248, 113, 113, 0.1);
+            --color-success: #4ade80;
+            --color-success-soft: rgba(74, 222, 128, 0.1);
+            --color-warning: #fbbf24;
+            --color-warning-soft: rgba(251, 191, 36, 0.1);
+            --color-pending: #d4a017;
+            --color-pending-soft: rgba(212, 160, 23, 0.15);
+        }
+        :root[data-theme="dark"] .replies-container .entry { border-color: var(--border); }
+        :root[data-theme="dark"] .only-you-badge { background: rgba(200, 200, 200, 0.08); }
+
+        /* Dark mode — system preference (when no manual override) */
         @media (prefers-color-scheme: dark) {
-            :root {
+            :root:not([data-theme]) {
                 --bg: #0e0d0b;
                 --surface: #161513;
                 --surface-raised: #1e1d1a;
@@ -1805,16 +1832,30 @@
                 --color-pending: #d4a017;
                 --color-pending-soft: rgba(212, 160, 23, 0.15);
             }
+            :root:not([data-theme]) .replies-container .entry { border-color: var(--border); }
+            :root:not([data-theme]) .only-you-badge { background: rgba(200, 200, 200, 0.08); }
+        }
 
-            .replies-container .entry {
-                border-color: var(--border);
-            }
-
-            .only-you-badge {
-                background: rgba(200, 200, 200, 0.08);
-            }
+        /* View transition — radial theme reveal */
+        ::view-transition-old(root),
+        ::view-transition-new(root) {
+            animation: none;
+            mix-blend-mode: normal;
+        }
+        ::view-transition-old(root) {
+            z-index: 1;
+        }
+        ::view-transition-new(root) {
+            z-index: 9999;
         }
     </style>
+    <script>
+        // Apply saved theme before paint to prevent flash
+        (function() {
+            const saved = document.cookie.match(/(?:^|; )hermes_theme=(\w+)/);
+            if (saved) document.documentElement.setAttribute('data-theme', saved[1]);
+        })();
+    </script>
 </head>
 <body>
     <div class="top-toolbar">
@@ -1915,6 +1956,58 @@
     </div>
 
     <script>
+        // ── Theme toggle ──
+        function getEffectiveTheme() {
+            const attr = document.documentElement.getAttribute('data-theme');
+            if (attr) return attr;
+            return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+
+        function updateThemeIcon() {
+            const btn = document.getElementById('theme-toggle');
+            if (btn) btn.innerHTML = getEffectiveTheme() === 'dark'
+                ? '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path stroke-linecap="round" d="M12 1v2m0 18v2M4.22 4.22l1.42 1.42m12.72 12.72l1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>'
+                : '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>';
+        }
+
+        function toggleTheme(e) {
+            const current = getEffectiveTheme();
+            const next = current === 'dark' ? 'light' : 'dark';
+
+            const applyTheme = () => {
+                document.documentElement.setAttribute('data-theme', next);
+                document.cookie = `hermes_theme=${next};path=/;max-age=${60*60*24*365};SameSite=Lax`;
+                updateThemeIcon();
+            };
+
+            // Radial reveal via View Transitions API
+            if (document.startViewTransition) {
+                const btn = document.getElementById('theme-toggle');
+                const rect = btn ? btn.getBoundingClientRect() : { left: window.innerWidth / 2, top: 0, width: 0, height: 0 };
+                const cx = rect.left + rect.width / 2;
+                const cy = rect.top + rect.height / 2;
+                const maxR = Math.hypot(
+                    Math.max(cx, window.innerWidth - cx),
+                    Math.max(cy, window.innerHeight - cy)
+                );
+
+                const t = document.startViewTransition(applyTheme);
+                t.ready.then(() => {
+                    document.documentElement.animate(
+                        { clipPath: [`circle(0px at ${cx}px ${cy}px)`, `circle(${maxR}px at ${cx}px ${cy}px)`] },
+                        { duration: 450, easing: 'ease-out', pseudoElement: '::view-transition-new(root)' }
+                    );
+                });
+            } else {
+                applyTheme();
+            }
+        }
+
+        // Set icon once DOM is ready
+        updateThemeIcon();
+        // Update icon if system preference changes (only matters when no cookie set)
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', updateThemeIcon);
+
         // Get URL params
         const params = new URLSearchParams(window.location.search);
         const filterPseudonym = params.get('pseudonym');

--- a/join.html
+++ b/join.html
@@ -31,8 +31,25 @@
             --error: #dc2626;
         }
 
+        :root[data-theme="dark"] {
+            --bg: #0e0d0b;
+            --surface: #161513;
+            --surface-raised: #1e1d1a;
+            --border: #2e2c28;
+            --border-subtle: #232220;
+            --fg: #e7e5e0;
+            --fg-muted: #a8a49d;
+            --fg-faint: #6b6860;
+            --accent: #a78bfa;
+            --accent-hover: #b9a0fc;
+            --accent-subtle: rgba(167, 139, 250, 0.1);
+            --accent-surface: rgba(167, 139, 250, 0.04);
+            --success: #4ade80;
+            --error: #f87171;
+        }
+
         @media (prefers-color-scheme: dark) {
-            :root {
+            :root:not([data-theme]) {
                 --bg: #0e0d0b;
                 --surface: #161513;
                 --surface-raised: #1e1d1a;
@@ -472,6 +489,13 @@
             display: none;
         }
     </style>
+    <script>
+        // Apply saved theme before paint to prevent flash
+        (function() {
+            const saved = document.cookie.match(/(?:^|; )hermes_theme=(\w+)/);
+            if (saved) document.documentElement.setAttribute('data-theme', saved[1]);
+        })();
+    </script>
 </head>
 <body>
     <div class="container">

--- a/join.html
+++ b/join.html
@@ -15,26 +15,38 @@
         }
 
         :root {
-            --bg: #faf9f7;
-            --surface: #ffffff;
-            --border: #e8e6e3;
-            --fg: #1a1a1a;
-            --fg-muted: #6b6b6b;
+            --bg: #e8e4db;
+            --surface: #f4f2ec;
+            --surface-raised: #fdfcf9;
+            --border: #c9c3b8;
+            --border-subtle: #dbd6cc;
+            --fg: #1c1917;
+            --fg-muted: #57534e;
+            --fg-faint: #78716c;
             --accent: #7c5cbf;
-            --accent-soft: rgba(124, 92, 191, 0.1);
-            --success: #81c784;
-            --error: #e57373;
+            --accent-hover: #6b4dab;
+            --accent-subtle: rgba(124, 92, 191, 0.08);
+            --accent-surface: rgba(124, 92, 191, 0.04);
+            --success: #16a34a;
+            --error: #dc2626;
         }
 
         @media (prefers-color-scheme: dark) {
             :root {
-                --bg: #0a0a0b;
-                --surface: #111113;
-                --border: #2a2a2e;
-                --fg: #e4e4e7;
-                --fg-muted: #8b8b8b;
+                --bg: #0e0d0b;
+                --surface: #161513;
+                --surface-raised: #1e1d1a;
+                --border: #2e2c28;
+                --border-subtle: #232220;
+                --fg: #e7e5e0;
+                --fg-muted: #a8a49d;
+                --fg-faint: #6b6860;
                 --accent: #a78bfa;
-                --accent-soft: rgba(167, 139, 250, 0.1);
+                --accent-hover: #b9a0fc;
+                --accent-subtle: rgba(167, 139, 250, 0.1);
+                --accent-surface: rgba(167, 139, 250, 0.04);
+                --success: #4ade80;
+                --error: #f87171;
             }
         }
 
@@ -47,6 +59,7 @@
             align-items: center;
             justify-content: center;
             padding: 2rem;
+            -webkit-font-smoothing: antialiased;
         }
 
         .container {
@@ -100,7 +113,7 @@
 
         .handle-input-wrapper:focus-within {
             border-color: var(--accent);
-            box-shadow: 0 0 0 3px var(--accent-soft);
+            box-shadow: 0 0 0 3px var(--accent-subtle);
         }
 
         .handle-input-wrapper .at {
@@ -193,7 +206,7 @@
 
         .text-input:focus {
             border-color: var(--accent);
-            box-shadow: 0 0 0 3px var(--accent-soft);
+            box-shadow: 0 0 0 3px var(--accent-subtle);
         }
 
         .text-input::placeholder {
@@ -470,7 +483,7 @@
             </div>
 
             <!-- Channel invite banner (hidden by default) -->
-            <div id="invite-banner" style="display:none; background: var(--accent-soft); border: 1px solid var(--accent); border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 1.5rem;">
+            <div id="invite-banner" style="display:none; background: var(--accent-subtle); border: 1px solid var(--accent); border-radius: 8px; padding: 1rem 1.25rem; margin-bottom: 1.5rem;">
                 <div style="font-family: 'IBM Plex Mono', monospace; font-size: 0.8rem; color: var(--accent); font-weight: 500;" id="invite-channel-name"></div>
                 <div style="font-size: 0.9rem; color: var(--fg-muted); margin-top: 0.25rem;" id="invite-channel-desc"></div>
             </div>

--- a/profile.html
+++ b/profile.html
@@ -16,12 +16,18 @@
         }
 
         :root {
-            --bg: #faf9f7;
-            --surface: #ffffff;
-            --border: #e8e6e3;
-            --fg: #1a1a1a;
-            --fg-muted: #6b6b6b;
+            --bg: #e8e4db;
+            --surface: #f4f2ec;
+            --surface-raised: #fdfcf9;
+            --border: #c9c3b8;
+            --border-subtle: #dbd6cc;
+            --fg: #1c1917;
+            --fg-muted: #57534e;
+            --fg-faint: #78716c;
             --accent: #7c5cbf;
+            --accent-hover: #6b4dab;
+            --accent-subtle: rgba(124, 92, 191, 0.08);
+            --accent-surface: rgba(124, 92, 191, 0.04);
         }
 
         body {
@@ -29,11 +35,12 @@
             background: var(--bg);
             color: var(--fg);
             min-height: 100vh;
+            -webkit-font-smoothing: antialiased;
         }
 
         .container {
             display: grid;
-            grid-template-columns: 300px 1fr;
+            grid-template-columns: 320px 1fr;
             min-height: 100vh;
         }
 
@@ -52,10 +59,11 @@
         .back-link {
             font-family: 'IBM Plex Mono', monospace;
             font-size: 0.75rem;
-            color: var(--fg-muted);
+            color: var(--fg-faint);
             text-decoration: none;
             margin-bottom: 1.5rem;
             display: inline-block;
+            transition: color 0.15s;
         }
 
         .back-link:hover {
@@ -70,7 +78,7 @@
             font-size: 1.5rem;
             font-weight: 500;
             font-style: italic;
-            letter-spacing: -0.02em;
+            letter-spacing: -0.03em;
             color: var(--accent);
         }
 
@@ -220,7 +228,7 @@
         }
 
         .delete-btn:hover {
-            color: #e53935;
+            color: #dc2626;
             background: rgba(229, 57, 53, 0.1);
         }
 
@@ -446,7 +454,7 @@
         .reflection-badge {
             display: inline-block;
             padding: 0.15rem 0.4rem;
-            background: rgba(124, 92, 191, 0.1);
+            background: var(--accent-subtle);
             color: var(--accent);
             border-radius: 3px;
             font-family: 'IBM Plex Mono', monospace;
@@ -471,7 +479,7 @@
 
         .error-state {
             padding: 4rem 0;
-            color: #e53935;
+            color: #dc2626;
         }
 
         /* Edit button */
@@ -643,12 +651,18 @@
         /* Dark mode */
         @media (prefers-color-scheme: dark) {
             :root {
-                --bg: #0a0a0b;
-                --surface: #111113;
-                --border: #2a2a2e;
-                --fg: #e4e4e7;
-                --fg-muted: #8b8b8b;
+                --bg: #0e0d0b;
+                --surface: #161513;
+                --surface-raised: #1e1d1a;
+                --border: #2e2c28;
+                --border-subtle: #232220;
+                --fg: #e7e5e0;
+                --fg-muted: #a8a49d;
+                --fg-faint: #6b6860;
                 --accent: #a78bfa;
+                --accent-hover: #b9a0fc;
+                --accent-subtle: rgba(167, 139, 250, 0.1);
+                --accent-surface: rgba(167, 139, 250, 0.04);
             }
         }
     </style>

--- a/profile.html
+++ b/profile.html
@@ -28,6 +28,8 @@
             --accent-hover: #6b4dab;
             --accent-subtle: rgba(124, 92, 191, 0.08);
             --accent-surface: rgba(124, 92, 191, 0.04);
+            --color-error: #dc2626;
+            --color-error-soft: rgba(220, 38, 38, 0.1);
         }
 
         body {
@@ -228,8 +230,8 @@
         }
 
         .delete-btn:hover {
-            color: #dc2626;
-            background: rgba(229, 57, 53, 0.1);
+            color: var(--color-error);
+            background: var(--color-error-soft);
         }
 
         .discuss-link {
@@ -479,7 +481,7 @@
 
         .error-state {
             padding: 4rem 0;
-            color: #dc2626;
+            color: var(--color-error);
         }
 
         /* Edit button */
@@ -662,6 +664,8 @@
             --accent-hover: #b9a0fc;
             --accent-subtle: rgba(167, 139, 250, 0.1);
             --accent-surface: rgba(167, 139, 250, 0.04);
+            --color-error: #f87171;
+            --color-error-soft: rgba(248, 113, 113, 0.1);
         }
 
         /* Dark mode — system preference (when no manual override) */
@@ -679,6 +683,8 @@
                 --accent-hover: #b9a0fc;
                 --accent-subtle: rgba(167, 139, 250, 0.1);
                 --accent-surface: rgba(167, 139, 250, 0.04);
+                --color-error: #f87171;
+                --color-error-soft: rgba(248, 113, 113, 0.1);
             }
         }
     </style>

--- a/profile.html
+++ b/profile.html
@@ -648,9 +648,25 @@
             }
         }
 
-        /* Dark mode */
+        /* Dark mode — explicit toggle */
+        :root[data-theme="dark"] {
+            --bg: #0e0d0b;
+            --surface: #161513;
+            --surface-raised: #1e1d1a;
+            --border: #2e2c28;
+            --border-subtle: #232220;
+            --fg: #e7e5e0;
+            --fg-muted: #a8a49d;
+            --fg-faint: #6b6860;
+            --accent: #a78bfa;
+            --accent-hover: #b9a0fc;
+            --accent-subtle: rgba(167, 139, 250, 0.1);
+            --accent-surface: rgba(167, 139, 250, 0.04);
+        }
+
+        /* Dark mode — system preference (when no manual override) */
         @media (prefers-color-scheme: dark) {
-            :root {
+            :root:not([data-theme]) {
                 --bg: #0e0d0b;
                 --surface: #161513;
                 --surface-raised: #1e1d1a;
@@ -666,6 +682,13 @@
             }
         }
     </style>
+    <script>
+        // Apply saved theme before paint to prevent flash
+        (function() {
+            const saved = document.cookie.match(/(?:^|; )hermes_theme=(\w+)/);
+            if (saved) document.documentElement.setAttribute('data-theme', saved[1]);
+        })();
+    </script>
 </head>
 <body>
     <div class="container">

--- a/prompt.html
+++ b/prompt.html
@@ -29,8 +29,23 @@
             --accent-surface: rgba(124, 92, 191, 0.04);
         }
 
+        :root[data-theme="dark"] {
+            --bg: #0e0d0b;
+            --surface: #161513;
+            --surface-raised: #1e1d1a;
+            --border: #2e2c28;
+            --border-subtle: #232220;
+            --fg: #e7e5e0;
+            --fg-muted: #a8a49d;
+            --fg-faint: #6b6860;
+            --accent: #a78bfa;
+            --accent-hover: #b9a0fc;
+            --accent-subtle: rgba(167, 139, 250, 0.1);
+            --accent-surface: rgba(167, 139, 250, 0.04);
+        }
+
         @media (prefers-color-scheme: dark) {
-            :root {
+            :root:not([data-theme]) {
                 --bg: #0e0d0b;
                 --surface: #161513;
                 --surface-raised: #1e1d1a;
@@ -116,6 +131,13 @@
             opacity: 0.7;
         }
     </style>
+    <script>
+        // Apply saved theme before paint to prevent flash
+        (function() {
+            const saved = document.cookie.match(/(?:^|; )hermes_theme=(\w+)/);
+            if (saved) document.documentElement.setAttribute('data-theme', saved[1]);
+        })();
+    </script>
 </head>
 <body>
     <div class="container">

--- a/prompt.html
+++ b/prompt.html
@@ -15,22 +15,34 @@
         }
 
         :root {
-            --bg: #faf9f7;
-            --surface: #ffffff;
-            --border: #e8e6e3;
-            --fg: #1a1a1a;
-            --fg-muted: #6b6b6b;
+            --bg: #e8e4db;
+            --surface: #f4f2ec;
+            --surface-raised: #fdfcf9;
+            --border: #c9c3b8;
+            --border-subtle: #dbd6cc;
+            --fg: #1c1917;
+            --fg-muted: #57534e;
+            --fg-faint: #78716c;
             --accent: #7c5cbf;
+            --accent-hover: #6b4dab;
+            --accent-subtle: rgba(124, 92, 191, 0.08);
+            --accent-surface: rgba(124, 92, 191, 0.04);
         }
 
         @media (prefers-color-scheme: dark) {
             :root {
-                --bg: #0a0a0b;
-                --surface: #111113;
-                --border: #2a2a2e;
-                --fg: #e4e4e7;
-                --fg-muted: #8b8b8b;
+                --bg: #0e0d0b;
+                --surface: #161513;
+                --surface-raised: #1e1d1a;
+                --border: #2e2c28;
+                --border-subtle: #232220;
+                --fg: #e7e5e0;
+                --fg-muted: #a8a49d;
+                --fg-faint: #6b6860;
                 --accent: #a78bfa;
+                --accent-hover: #b9a0fc;
+                --accent-subtle: rgba(167, 139, 250, 0.1);
+                --accent-surface: rgba(167, 139, 250, 0.04);
             }
         }
 
@@ -40,6 +52,7 @@
             color: var(--fg);
             min-height: 100vh;
             padding: 3rem 2rem;
+            -webkit-font-smoothing: antialiased;
         }
 
         .container {

--- a/release.html
+++ b/release.html
@@ -16,12 +16,50 @@
         }
 
         :root {
-            --bg: #faf9f7;
-            --surface: #ffffff;
-            --border: #e8e6e3;
-            --fg: #1a1a1a;
-            --fg-muted: #6b6b6b;
+            --bg: #e8e4db;
+            --surface: #f4f2ec;
+            --surface-raised: #fdfcf9;
+            --border: #c9c3b8;
+            --border-subtle: #dbd6cc;
+            --fg: #1c1917;
+            --fg-muted: #57534e;
+            --fg-faint: #78716c;
             --accent: #7c5cbf;
+            --accent-hover: #6b4dab;
+            --accent-subtle: rgba(124, 92, 191, 0.08);
+            --accent-surface: rgba(124, 92, 191, 0.04);
+        }
+
+        :root[data-theme="dark"] {
+            --bg: #0e0d0b;
+            --surface: #161513;
+            --surface-raised: #1e1d1a;
+            --border: #2e2c28;
+            --border-subtle: #232220;
+            --fg: #e7e5e0;
+            --fg-muted: #a8a49d;
+            --fg-faint: #6b6860;
+            --accent: #a78bfa;
+            --accent-hover: #b9a0fc;
+            --accent-subtle: rgba(167, 139, 250, 0.1);
+            --accent-surface: rgba(167, 139, 250, 0.04);
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root:not([data-theme]) {
+                --bg: #0e0d0b;
+                --surface: #161513;
+                --surface-raised: #1e1d1a;
+                --border: #2e2c28;
+                --border-subtle: #232220;
+                --fg: #e7e5e0;
+                --fg-muted: #a8a49d;
+                --fg-faint: #6b6860;
+                --accent: #a78bfa;
+                --accent-hover: #b9a0fc;
+                --accent-subtle: rgba(167, 139, 250, 0.1);
+                --accent-surface: rgba(167, 139, 250, 0.04);
+            }
         }
 
         body {
@@ -30,6 +68,7 @@
             color: var(--fg);
             min-height: 100vh;
             line-height: 1.7;
+            -webkit-font-smoothing: antialiased;
         }
 
         .header {
@@ -240,6 +279,13 @@
             }
         }
     </style>
+    <script>
+        // Apply saved theme before paint to prevent flash
+        (function() {
+            const saved = document.cookie.match(/(?:^|; )hermes_theme=(\w+)/);
+            if (saved) document.documentElement.setAttribute('data-theme', saved[1]);
+        })();
+    </script>
 </head>
 <body>
     <header class="header">

--- a/settings.html
+++ b/settings.html
@@ -32,8 +32,26 @@
             --warning: #d97706;
         }
 
+        :root[data-theme="dark"] {
+            --bg: #0e0d0b;
+            --surface: #161513;
+            --surface-raised: #1e1d1a;
+            --border: #2e2c28;
+            --border-subtle: #232220;
+            --fg: #e7e5e0;
+            --fg-muted: #a8a49d;
+            --fg-faint: #6b6860;
+            --accent: #a78bfa;
+            --accent-hover: #b9a0fc;
+            --accent-subtle: rgba(167, 139, 250, 0.1);
+            --accent-surface: rgba(167, 139, 250, 0.04);
+            --success: #4ade80;
+            --error: #f87171;
+            --warning: #fbbf24;
+        }
+
         @media (prefers-color-scheme: dark) {
-            :root {
+            :root:not([data-theme]) {
                 --bg: #0e0d0b;
                 --surface: #161513;
                 --surface-raised: #1e1d1a;
@@ -463,6 +481,13 @@
             display: none !important;
         }
     </style>
+    <script>
+        // Apply saved theme before paint to prevent flash
+        (function() {
+            const saved = document.cookie.match(/(?:^|; )hermes_theme=(\w+)/);
+            if (saved) document.documentElement.setAttribute('data-theme', saved[1]);
+        })();
+    </script>
 </head>
 <body>
     <div class="container">

--- a/settings.html
+++ b/settings.html
@@ -15,27 +15,40 @@
         }
 
         :root {
-            --bg: #faf9f7;
-            --surface: #ffffff;
-            --border: #e8e6e3;
-            --fg: #1a1a1a;
-            --fg-muted: #6b6b6b;
+            --bg: #e8e4db;
+            --surface: #f4f2ec;
+            --surface-raised: #fdfcf9;
+            --border: #c9c3b8;
+            --border-subtle: #dbd6cc;
+            --fg: #1c1917;
+            --fg-muted: #57534e;
+            --fg-faint: #78716c;
             --accent: #7c5cbf;
-            --accent-soft: rgba(124, 92, 191, 0.1);
-            --success: #81c784;
-            --error: #e57373;
-            --warning: #ffb74d;
+            --accent-hover: #6b4dab;
+            --accent-subtle: rgba(124, 92, 191, 0.08);
+            --accent-surface: rgba(124, 92, 191, 0.04);
+            --success: #16a34a;
+            --error: #dc2626;
+            --warning: #d97706;
         }
 
         @media (prefers-color-scheme: dark) {
             :root {
-                --bg: #0a0a0b;
-                --surface: #111113;
-                --border: #2a2a2e;
-                --fg: #e4e4e7;
-                --fg-muted: #8b8b8b;
+                --bg: #0e0d0b;
+                --surface: #161513;
+                --surface-raised: #1e1d1a;
+                --border: #2e2c28;
+                --border-subtle: #232220;
+                --fg: #e7e5e0;
+                --fg-muted: #a8a49d;
+                --fg-faint: #6b6860;
                 --accent: #a78bfa;
-                --accent-soft: rgba(167, 139, 250, 0.1);
+                --accent-hover: #b9a0fc;
+                --accent-subtle: rgba(167, 139, 250, 0.1);
+                --accent-surface: rgba(167, 139, 250, 0.04);
+                --success: #4ade80;
+                --error: #f87171;
+                --warning: #fbbf24;
             }
         }
 
@@ -45,6 +58,7 @@
             color: var(--fg);
             min-height: 100vh;
             padding: 2rem;
+            -webkit-font-smoothing: antialiased;
         }
 
         .container {
@@ -96,7 +110,7 @@
 
         /* Upgrade banner for legacy users */
         .upgrade-banner {
-            background: var(--accent-soft);
+            background: var(--accent-subtle);
             border: 1px solid var(--accent);
             border-radius: 8px;
             padding: 1.25rem;
@@ -237,7 +251,7 @@
 
         .text-input:focus {
             border-color: var(--accent);
-            box-shadow: 0 0 0 3px var(--accent-soft);
+            box-shadow: 0 0 0 3px var(--accent-subtle);
         }
 
         .text-input.mono {

--- a/setup.html
+++ b/setup.html
@@ -182,19 +182,19 @@
         }
 
         .generate-btn {
-            background: var(--fg);
-            color: var(--bg);
+            background: var(--accent);
+            color: white;
             border: none;
             border-radius: 6px;
             padding: 0.75rem 1.5rem;
             font-family: 'IBM Plex Mono', monospace;
             font-size: 0.85rem;
             cursor: pointer;
-            transition: background 0.2s;
+            transition: opacity 0.2s;
         }
 
         .generate-btn:hover {
-            background: var(--accent);
+            opacity: 0.9;
         }
 
         .key-display {

--- a/setup.html
+++ b/setup.html
@@ -27,6 +27,8 @@
             --accent-hover: #6b4dab;
             --accent-subtle: rgba(124, 92, 191, 0.08);
             --accent-surface: rgba(124, 92, 191, 0.04);
+            --color-error: #dc2626;
+            --color-success: #16a34a;
         }
 
         :root[data-theme="dark"] {
@@ -42,6 +44,8 @@
             --accent-hover: #b9a0fc;
             --accent-subtle: rgba(167, 139, 250, 0.1);
             --accent-surface: rgba(167, 139, 250, 0.04);
+            --color-error: #f87171;
+            --color-success: #4ade80;
         }
 
         @media (prefers-color-scheme: dark) {
@@ -58,6 +62,8 @@
                 --accent-hover: #b9a0fc;
                 --accent-subtle: rgba(167, 139, 250, 0.1);
                 --accent-surface: rgba(167, 139, 250, 0.04);
+                --color-error: #f87171;
+                --color-success: #4ade80;
             }
         }
 
@@ -624,7 +630,7 @@ GET /api/search?q=keyword</code>
 
             if (!/^[a-z]/.test(handle)) {
                 status.textContent = 'Handle must start with a letter';
-                status.style.color = '#e57373';
+                status.style.color = 'var(--color-error)';
                 btn.disabled = true;
                 return;
             }
@@ -639,16 +645,16 @@ GET /api/search?q=keyword</code>
 
                     if (data.available) {
                         status.textContent = '✓ Available';
-                        status.style.color = '#81c784';
+                        status.style.color = 'var(--color-success)';
                         btn.disabled = false;
                     } else {
                         status.textContent = '✗ Already taken';
-                        status.style.color = '#e57373';
+                        status.style.color = 'var(--color-error)';
                         btn.disabled = true;
                     }
                 } catch (err) {
                     status.textContent = 'Error checking availability';
-                    status.style.color = '#e57373';
+                    status.style.color = 'var(--color-error)';
                     btn.disabled = true;
                 }
             }, 300);
@@ -672,7 +678,7 @@ GET /api/search?q=keyword</code>
 
             if (!/^[a-z]/.test(handle)) {
                 status.textContent = 'Handle must start with a letter';
-                status.style.color = '#e57373';
+                status.style.color = 'var(--color-error)';
                 btn.disabled = true;
                 return;
             }
@@ -687,16 +693,16 @@ GET /api/search?q=keyword</code>
 
                     if (data.available) {
                         status.textContent = '✓ Available';
-                        status.style.color = '#81c784';
+                        status.style.color = 'var(--color-success)';
                         btn.disabled = false;
                     } else {
                         status.textContent = '✗ Already taken';
-                        status.style.color = '#e57373';
+                        status.style.color = 'var(--color-error)';
                         btn.disabled = true;
                     }
                 } catch (err) {
                     status.textContent = 'Error checking availability';
-                    status.style.color = '#e57373';
+                    status.style.color = 'var(--color-error)';
                     btn.disabled = true;
                 }
             }, 300);

--- a/setup.html
+++ b/setup.html
@@ -15,22 +15,34 @@
         }
 
         :root {
-            --bg: #faf9f7;
-            --surface: #ffffff;
-            --border: #e8e6e3;
-            --fg: #1a1a1a;
-            --fg-muted: #6b6b6b;
+            --bg: #e8e4db;
+            --surface: #f4f2ec;
+            --surface-raised: #fdfcf9;
+            --border: #c9c3b8;
+            --border-subtle: #dbd6cc;
+            --fg: #1c1917;
+            --fg-muted: #57534e;
+            --fg-faint: #78716c;
             --accent: #7c5cbf;
+            --accent-hover: #6b4dab;
+            --accent-subtle: rgba(124, 92, 191, 0.08);
+            --accent-surface: rgba(124, 92, 191, 0.04);
         }
 
         @media (prefers-color-scheme: dark) {
             :root {
-                --bg: #0a0a0b;
-                --surface: #111113;
-                --border: #2a2a2e;
-                --fg: #e4e4e7;
-                --fg-muted: #8b8b8b;
+                --bg: #0e0d0b;
+                --surface: #161513;
+                --surface-raised: #1e1d1a;
+                --border: #2e2c28;
+                --border-subtle: #232220;
+                --fg: #e7e5e0;
+                --fg-muted: #a8a49d;
+                --fg-faint: #6b6860;
                 --accent: #a78bfa;
+                --accent-hover: #b9a0fc;
+                --accent-subtle: rgba(167, 139, 250, 0.1);
+                --accent-surface: rgba(167, 139, 250, 0.04);
             }
         }
 
@@ -40,6 +52,7 @@
             color: var(--fg);
             min-height: 100vh;
             padding: 3rem 2rem;
+            -webkit-font-smoothing: antialiased;
         }
 
         .container {
@@ -122,8 +135,8 @@
         }
 
         .note {
-            background: rgba(167, 139, 250, 0.1);
-            border: 1px solid rgba(167, 139, 250, 0.2);
+            background: var(--accent-subtle);
+            border: 1px solid var(--border);
             border-radius: 6px;
             padding: 1rem 1.25rem;
             font-size: 0.85rem;
@@ -148,19 +161,19 @@
         }
 
         .generate-btn {
-            background: var(--accent);
-            color: white;
+            background: var(--fg);
+            color: var(--bg);
             border: none;
             border-radius: 6px;
             padding: 0.75rem 1.5rem;
             font-family: 'IBM Plex Mono', monospace;
             font-size: 0.85rem;
             cursor: pointer;
-            transition: opacity 0.2s;
+            transition: background 0.2s;
         }
 
         .generate-btn:hover {
-            opacity: 0.9;
+            background: var(--accent);
         }
 
         .key-display {

--- a/setup.html
+++ b/setup.html
@@ -29,8 +29,23 @@
             --accent-surface: rgba(124, 92, 191, 0.04);
         }
 
+        :root[data-theme="dark"] {
+            --bg: #0e0d0b;
+            --surface: #161513;
+            --surface-raised: #1e1d1a;
+            --border: #2e2c28;
+            --border-subtle: #232220;
+            --fg: #e7e5e0;
+            --fg-muted: #a8a49d;
+            --fg-faint: #6b6860;
+            --accent: #a78bfa;
+            --accent-hover: #b9a0fc;
+            --accent-subtle: rgba(167, 139, 250, 0.1);
+            --accent-surface: rgba(167, 139, 250, 0.04);
+        }
+
         @media (prefers-color-scheme: dark) {
-            :root {
+            :root:not([data-theme]) {
                 --bg: #0e0d0b;
                 --surface: #161513;
                 --surface-raised: #1e1d1a;
@@ -257,6 +272,13 @@
             flex-shrink: 0;
         }
     </style>
+    <script>
+        // Apply saved theme before paint to prevent flash
+        (function() {
+            const saved = document.cookie.match(/(?:^|; )hermes_theme=(\w+)/);
+            if (saved) document.documentElement.setAttribute('data-theme', saved[1]);
+        })();
+    </script>
 </head>
 <body>
     <div class="container">

--- a/unsubscribe.html
+++ b/unsubscribe.html
@@ -15,22 +15,49 @@
         }
 
         :root {
-            --bg: #faf9f7;
-            --surface: #ffffff;
-            --border: #e8e6e3;
-            --fg: #1a1a1a;
-            --fg-muted: #6b6b6b;
+            --bg: #e8e4db;
+            --surface: #f4f2ec;
+            --surface-raised: #fdfcf9;
+            --border: #c9c3b8;
+            --border-subtle: #dbd6cc;
+            --fg: #1c1917;
+            --fg-muted: #57534e;
+            --fg-faint: #78716c;
             --accent: #7c5cbf;
+            --accent-hover: #6b4dab;
+            --accent-subtle: rgba(124, 92, 191, 0.08);
+            --accent-surface: rgba(124, 92, 191, 0.04);
+        }
+
+        :root[data-theme="dark"] {
+            --bg: #0e0d0b;
+            --surface: #161513;
+            --surface-raised: #1e1d1a;
+            --border: #2e2c28;
+            --border-subtle: #232220;
+            --fg: #e7e5e0;
+            --fg-muted: #a8a49d;
+            --fg-faint: #6b6860;
+            --accent: #a78bfa;
+            --accent-hover: #b9a0fc;
+            --accent-subtle: rgba(167, 139, 250, 0.1);
+            --accent-surface: rgba(167, 139, 250, 0.04);
         }
 
         @media (prefers-color-scheme: dark) {
-            :root {
-                --bg: #0a0a0b;
-                --surface: #111113;
-                --border: #2a2a2e;
-                --fg: #e4e4e7;
-                --fg-muted: #8b8b8b;
+            :root:not([data-theme]) {
+                --bg: #0e0d0b;
+                --surface: #161513;
+                --surface-raised: #1e1d1a;
+                --border: #2e2c28;
+                --border-subtle: #232220;
+                --fg: #e7e5e0;
+                --fg-muted: #a8a49d;
+                --fg-faint: #6b6860;
                 --accent: #a78bfa;
+                --accent-hover: #b9a0fc;
+                --accent-subtle: rgba(167, 139, 250, 0.1);
+                --accent-surface: rgba(167, 139, 250, 0.04);
             }
         }
 
@@ -40,6 +67,7 @@
             color: var(--fg);
             min-height: 100vh;
             padding: 3rem 2rem;
+            -webkit-font-smoothing: antialiased;
         }
 
         .container {
@@ -103,6 +131,13 @@
             margin-bottom: 0.5rem;
         }
     </style>
+    <script>
+        // Apply saved theme before paint to prevent flash
+        (function() {
+            const saved = document.cookie.match(/(?:^|; )hermes_theme=(\w+)/);
+            if (saved) document.documentElement.setAttribute('data-theme', saved[1]);
+        })();
+    </script>
 </head>
 <body>
     <div class="container">

--- a/verify-email.html
+++ b/verify-email.html
@@ -15,24 +15,55 @@
         }
 
         :root {
-            --bg: #faf9f7;
-            --surface: #ffffff;
-            --border: #e8e6e3;
-            --fg: #1a1a1a;
-            --fg-muted: #6b6b6b;
+            --bg: #e8e4db;
+            --surface: #f4f2ec;
+            --surface-raised: #fdfcf9;
+            --border: #c9c3b8;
+            --border-subtle: #dbd6cc;
+            --fg: #1c1917;
+            --fg-muted: #57534e;
+            --fg-faint: #78716c;
             --accent: #7c5cbf;
-            --success: #4caf50;
+            --accent-hover: #6b4dab;
+            --accent-subtle: rgba(124, 92, 191, 0.08);
+            --accent-surface: rgba(124, 92, 191, 0.04);
+            --color-success: #16a34a;
+            --color-error: #dc2626;
+        }
+
+        :root[data-theme="dark"] {
+            --bg: #0e0d0b;
+            --surface: #161513;
+            --surface-raised: #1e1d1a;
+            --border: #2e2c28;
+            --border-subtle: #232220;
+            --fg: #e7e5e0;
+            --fg-muted: #a8a49d;
+            --fg-faint: #6b6860;
+            --accent: #a78bfa;
+            --accent-hover: #b9a0fc;
+            --accent-subtle: rgba(167, 139, 250, 0.1);
+            --accent-surface: rgba(167, 139, 250, 0.04);
+            --color-success: #4ade80;
+            --color-error: #f87171;
         }
 
         @media (prefers-color-scheme: dark) {
-            :root {
-                --bg: #0a0a0b;
-                --surface: #111113;
-                --border: #2a2a2e;
-                --fg: #e4e4e7;
-                --fg-muted: #8b8b8b;
+            :root:not([data-theme]) {
+                --bg: #0e0d0b;
+                --surface: #161513;
+                --surface-raised: #1e1d1a;
+                --border: #2e2c28;
+                --border-subtle: #232220;
+                --fg: #e7e5e0;
+                --fg-muted: #a8a49d;
+                --fg-faint: #6b6860;
                 --accent: #a78bfa;
-                --success: #81c784;
+                --accent-hover: #b9a0fc;
+                --accent-subtle: rgba(167, 139, 250, 0.1);
+                --accent-surface: rgba(167, 139, 250, 0.04);
+                --color-success: #4ade80;
+                --color-error: #f87171;
             }
         }
 
@@ -42,6 +73,7 @@
             color: var(--fg);
             min-height: 100vh;
             padding: 3rem 2rem;
+            -webkit-font-smoothing: antialiased;
         }
 
         .container {
@@ -73,13 +105,13 @@
         }
 
         .status.success {
-            border-color: rgba(129, 199, 132, 0.5);
-            background: rgba(129, 199, 132, 0.1);
+            border-color: color-mix(in srgb, var(--color-success) 50%, transparent);
+            background: color-mix(in srgb, var(--color-success) 10%, transparent);
         }
 
         .status.error {
-            border-color: rgba(229, 115, 115, 0.5);
-            background: rgba(229, 115, 115, 0.1);
+            border-color: color-mix(in srgb, var(--color-error) 50%, transparent);
+            background: color-mix(in srgb, var(--color-error) 10%, transparent);
         }
 
         .status.loading {
@@ -113,6 +145,13 @@
             margin-bottom: 1rem;
         }
     </style>
+    <script>
+        // Apply saved theme before paint to prevent flash
+        (function() {
+            const saved = document.cookie.match(/(?:^|; )hermes_theme=(\w+)/);
+            if (saved) document.documentElement.setAttribute('data-theme', saved[1]);
+        })();
+    </script>
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
> **Depends on [PR #7](https://github.com/jameslbarnes/hermes/pull/7)** (design-system tokens + dark mode). This branch is based on `design-system` — merge #7 first.

## Summary

Replaces the two-column sidebar layout with a sticky top bar and centered single-column feed (700px max-width). This is the core layout change split out from PR #5 for independent iteration.

- **Header**: sticky top bar with brand, subtitle, search, identity controls, theme toggle, and hamburger menu
- **Nav panel**: hamburger opens a contextual link panel (different links for logged-in vs anonymous users)
- **Channel pills**: horizontal scrollable pill bar replaces the sidebar channel list
- **Gear dropdown**: compact Settings + Sign out menu replaces sidebar identity block
- **Footer**: site-wide links including "Trust & attestation"
- **Responsive**: updated breakpoints at 900px and 480px (subtitle hides, padding tightens)

All design tokens from PR #7 preserved — no hardcoded colors or sizes introduced.

## Attestation note

`toggleVerifyMenu()` and `verifyWithClaude()` are removed in this PR. The sidebar's "Verify attestation" button and interactive prompt builder don't have a home in the new header layout. A dedicated `/trust.html` page is planned to absorb and expand on this functionality — the footer now links to `/trust` instead of `/api/attestation`.

## Verification

- Page loads with sticky top bar, no sidebar
- Feed centered at 700px max-width
- Hamburger opens/closes nav panel with contextual links
- Theme toggle button works (radial reveal animation)
- Channel pills appear for logged-in users with subscriptions
- Gear menu opens/closes with Settings + Sign out
- "Get started" button shows for anonymous users with onboard menu
- Footer visible at bottom with links
- Dark mode: all new elements respect theme
- Mobile (< 900px): feed padding tightens, pills scroll horizontally
- Narrow (< 480px): subtitle hides, padding tightens further
- Search still works from header position

## Test plan

- [ ] Load page without being logged in — "Get started" visible, no gear/import/inbox, nav panel shows anonymous links
- [ ] Load page logged in with handle — gear dropdown, import/inbox visible, channel pills populate
- [ ] Toggle dark mode — all new elements render correctly
- [ ] Test at 900px and 480px breakpoints
- [ ] Verify no hardcoded colors (`grep '#[0-9a-fA-F]'` in new/changed lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)