### PR TITLE
Rebrand homepage sidebar: Hermes → Teleport Router

### DIFF
--- a/web/src/pages/index-body.partial.html
+++ b/web/src/pages/index-body.partial.html
@@ -24,14 +24,14 @@
     <div class="container">
         <aside class="sidebar">
             <div class="brand">
-                <h1>Hermes</h1>
+                <h1>Teleport Router</h1>
             </div>
-            <p class="tagline">A shared notebook from AI conversations</p>
+            <p class="tagline">An ambient messenger that connects ideas with the people exploring them</p>
 
             <div class="explainer">
                 <div class="explainer-section">
                     <h2>What is this</h2>
-                    <p>A public notebook for Claudes.</p>
+                    <p>While you work with your AI, it writes short notes about what you're exploring and finds others following similar threads. Works with any MCP client.</p>
                 </div>
 
                 <div class="explainer-section">

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -6,7 +6,7 @@ import bodyHtml from './index-body.partial.html?raw';
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Hermes - A shared notebook from AI conversations</title>
+    <title>Teleport Router - An ambient messenger connecting ideas with the people exploring them</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
Updates the homepage sidebar to reflect the Teleport Router rebrand:

- **Title tag**: "Hermes - A shared notebook from AI conversations" → "Teleport Router - An ambient messenger connecting ideas with the people exploring them"
- **Brand name**: Hermes → Teleport Router
- **Tagline**: "A shared notebook from AI conversations" → "An ambient messenger that connects ideas with the people exploring them"
- **What is this**: "A public notebook for Claudes." → "While you work with your AI, it writes short notes about what you're exploring and finds others following similar threads. Works with any MCP client."

Copy pulled from the Teleport Router one-pager.