### PR TITLE
feat: Telegram topic management API

### DIFF
--- a/server/src/telegram/topic-manager.test.ts
+++ b/server/src/telegram/topic-manager.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TopicManager, type TelegramApi } from './topic-manager.js';
+
+// ─── Mock Telegram API ──────────────────────────────────────────────────────
+
+function createMockApi(): TelegramApi & {
+  calls: Array<{ method: string; args: unknown[] }>;
+} {
+  const calls: Array<{ method: string; args: unknown[] }> = [];
+
+  return {
+    calls,
+
+    createForumTopic: vi.fn(async (chatId: number | string, name: string) => {
+      calls.push({ method: 'createForumTopic', args: [chatId, name] });
+      return { message_thread_id: 42, name };
+    }),
+
+    closeForumTopic: vi.fn(async (...args: unknown[]) => {
+      calls.push({ method: 'closeForumTopic', args });
+      return true;
+    }),
+
+    reopenForumTopic: vi.fn(async (...args: unknown[]) => {
+      calls.push({ method: 'reopenForumTopic', args });
+      return true;
+    }),
+
+    deleteForumTopic: vi.fn(async (...args: unknown[]) => {
+      calls.push({ method: 'deleteForumTopic', args });
+      return true;
+    }),
+
+    sendMessage: vi.fn(async (chatId: number | string, text: string, extra?: Record<string, unknown>) => {
+      calls.push({ method: 'sendMessage', args: [chatId, text, extra] });
+      return { message_id: 100 };
+    }),
+
+    pinChatMessage: vi.fn(async (...args: unknown[]) => {
+      calls.push({ method: 'pinChatMessage', args });
+      return true;
+    }),
+
+    unpinChatMessage: vi.fn(async (...args: unknown[]) => {
+      calls.push({ method: 'unpinChatMessage', args });
+      return true;
+    }),
+
+    editForumTopic: vi.fn(async (...args: unknown[]) => {
+      calls.push({ method: 'editForumTopic', args });
+      return true;
+    }),
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+const DEFAULT_CHAT_ID = '-1001234567890';
+
+describe('TopicManager', () => {
+  let api: ReturnType<typeof createMockApi>;
+  let tm: TopicManager;
+
+  beforeEach(() => {
+    api = createMockApi();
+    tm = new TopicManager(api, DEFAULT_CHAT_ID);
+  });
+
+  // ── createTopic ──────────────────────────────────────────────────────────
+
+  describe('createTopic', () => {
+    it('calls createForumTopic with default chatId and returns threadId + name', async () => {
+      const result = await tm.createTopic('General');
+
+      expect(result).toEqual({ threadId: 42, name: 'General' });
+      expect(api.createForumTopic).toHaveBeenCalledWith(DEFAULT_CHAT_ID, 'General');
+    });
+
+    it('uses override chatId when provided', async () => {
+      await tm.createTopic('Off-topic', '-100999');
+
+      expect(api.createForumTopic).toHaveBeenCalledWith('-100999', 'Off-topic');
+    });
+  });
+
+  // ── closeTopic ───────────────────────────────────────────────────────────
+
+  describe('closeTopic', () => {
+    it('calls closeForumTopic with correct params', async () => {
+      await tm.closeTopic(42);
+
+      expect(api.closeForumTopic).toHaveBeenCalledWith(DEFAULT_CHAT_ID, 42);
+    });
+  });
+
+  // ── reopenTopic ──────────────────────────────────────────────────────────
+
+  describe('reopenTopic', () => {
+    it('calls reopenForumTopic with correct params', async () => {
+      await tm.reopenTopic(42);
+
+      expect(api.reopenForumTopic).toHaveBeenCalledWith(DEFAULT_CHAT_ID, 42);
+    });
+  });
+
+  // ── deleteTopic ──────────────────────────────────────────────────────────
+
+  describe('deleteTopic', () => {
+    it('calls deleteForumTopic with correct params', async () => {
+      await tm.deleteTopic(42);
+
+      expect(api.deleteForumTopic).toHaveBeenCalledWith(DEFAULT_CHAT_ID, 42);
+    });
+  });
+
+  // ── sendToTopic ──────────────────────────────────────────────────────────
+
+  describe('sendToTopic', () => {
+    it('passes message_thread_id in the extras', async () => {
+      const msgId = await tm.sendToTopic(42, 'Hello, topic!');
+
+      expect(msgId).toBe(100);
+      expect(api.sendMessage).toHaveBeenCalledWith(
+        DEFAULT_CHAT_ID,
+        'Hello, topic!',
+        { message_thread_id: 42 },
+      );
+    });
+
+    it('passes parse_mode and reply_to_message_id when provided', async () => {
+      await tm.sendToTopic(7, 'Bold text', {
+        parseMode: 'MarkdownV2',
+        replyToMessageId: 55,
+      });
+
+      expect(api.sendMessage).toHaveBeenCalledWith(
+        DEFAULT_CHAT_ID,
+        'Bold text',
+        {
+          message_thread_id: 7,
+          parse_mode: 'MarkdownV2',
+          reply_to_message_id: 55,
+        },
+      );
+    });
+
+    it('uses override chatId when provided', async () => {
+      await tm.sendToTopic(42, 'test', undefined, '-100888');
+
+      expect(api.sendMessage).toHaveBeenCalledWith(
+        '-100888',
+        'test',
+        { message_thread_id: 42 },
+      );
+    });
+  });
+
+  // ── pinInTopic / unpinInTopic ────────────────────────────────────────────
+
+  describe('pinInTopic', () => {
+    it('calls pinChatMessage with message_thread_id', async () => {
+      await tm.pinInTopic(42, 100);
+
+      expect(api.pinChatMessage).toHaveBeenCalledWith(
+        DEFAULT_CHAT_ID,
+        100,
+        { message_thread_id: 42 },
+      );
+    });
+
+    it('uses override chatId when provided', async () => {
+      await tm.pinInTopic(42, 100, '-100777');
+
+      expect(api.pinChatMessage).toHaveBeenCalledWith(
+        '-100777',
+        100,
+        { message_thread_id: 42 },
+      );
+    });
+  });
+
+  describe('unpinInTopic', () => {
+    it('calls unpinChatMessage with message_id and message_thread_id', async () => {
+      await tm.unpinInTopic(42, 100);
+
+      expect(api.unpinChatMessage).toHaveBeenCalledWith(
+        DEFAULT_CHAT_ID,
+        { message_thread_id: 42, message_id: 100 },
+      );
+    });
+  });
+
+  // ── editTopicName ────────────────────────────────────────────────────────
+
+  describe('editTopicName', () => {
+    it('calls editForumTopic with new name', async () => {
+      await tm.editTopicName(42, 'Renamed Topic');
+
+      expect(api.editForumTopic).toHaveBeenCalledWith(
+        DEFAULT_CHAT_ID,
+        42,
+        { name: 'Renamed Topic' },
+      );
+    });
+
+    it('uses override chatId when provided', async () => {
+      await tm.editTopicName(42, 'New Name', '-100666');
+
+      expect(api.editForumTopic).toHaveBeenCalledWith(
+        '-100666',
+        42,
+        { name: 'New Name' },
+      );
+    });
+  });
+
+  // ── Error handling ───────────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    it('catches API errors, logs them, and re-throws with a clean message', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      api.createForumTopic.mockRejectedValueOnce(new Error('Bad Request: chat not found'));
+
+      await expect(tm.createTopic('Fail')).rejects.toThrow(
+        '[Telegram/Topics] Failed to create topic "Fail"',
+      );
+
+      expect(consoleSpy).toHaveBeenCalled();
+      const loggedMessage = consoleSpy.mock.calls[0]?.[0] as string;
+      expect(loggedMessage).toContain('[Telegram/Topics]');
+      expect(loggedMessage).toContain('Failed to create topic');
+
+      consoleSpy.mockRestore();
+    });
+
+    it('re-throws errors from sendToTopic with context', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      api.sendMessage.mockRejectedValueOnce(new Error('Forbidden: bot was kicked'));
+
+      await expect(tm.sendToTopic(42, 'Hi')).rejects.toThrow(
+        '[Telegram/Topics] Failed to send message to topic 42',
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('re-throws errors from closeTopic with context', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      api.closeForumTopic.mockRejectedValueOnce(new Error('topic already closed'));
+
+      await expect(tm.closeTopic(99)).rejects.toThrow(
+        '[Telegram/Topics] Failed to close topic 99',
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('re-throws errors from deleteTopic with context', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      api.deleteForumTopic.mockRejectedValueOnce(new Error('not enough rights'));
+
+      await expect(tm.deleteTopic(77)).rejects.toThrow(
+        '[Telegram/Topics] Failed to delete topic 77',
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // ── Default chatId fallback ──────────────────────────────────────────────
+
+  describe('default chatId', () => {
+    it('uses default chatId for all methods when no override is provided', async () => {
+      await tm.createTopic('A');
+      await tm.closeTopic(1);
+      await tm.reopenTopic(2);
+      await tm.deleteTopic(3);
+      await tm.sendToTopic(4, 'msg');
+      await tm.pinInTopic(5, 10);
+      await tm.unpinInTopic(6, 11);
+      await tm.editTopicName(7, 'X');
+
+      // Every recorded call should use the default chat ID
+      for (const call of api.calls) {
+        expect(call.args[0]).toBe(DEFAULT_CHAT_ID);
+      }
+    });
+  });
+});

--- a/server/src/telegram/topic-manager.ts
+++ b/server/src/telegram/topic-manager.ts
@@ -1,0 +1,234 @@
+/**
+ * TopicManager — clean abstraction over Telegram's forum topic operations.
+ *
+ * Wraps Telegraf's Telegram API client for creating, managing, and messaging
+ * within forum topics. This is a pure Telegram abstraction with no dependencies
+ * on Hermes-specific types (no storage, no channels, no classifier).
+ *
+ * All methods accept an optional chatId override; if not provided, they fall
+ * back to the default chatId supplied at construction time.
+ */
+
+// We only need the Telegram API client type from Telegraf.
+// Using a structural interface so we don't tightly couple to Telegraf's exact type.
+export interface TelegramApi {
+  createForumTopic(
+    chatId: number | string,
+    name: string,
+  ): Promise<{ message_thread_id: number; name: string }>;
+
+  closeForumTopic(
+    chatId: number | string,
+    messageThreadId: number,
+  ): Promise<boolean>;
+
+  reopenForumTopic(
+    chatId: number | string,
+    messageThreadId: number,
+  ): Promise<boolean>;
+
+  deleteForumTopic(
+    chatId: number | string,
+    messageThreadId: number,
+  ): Promise<boolean>;
+
+  sendMessage(
+    chatId: number | string,
+    text: string,
+    extra?: Record<string, unknown>,
+  ): Promise<{ message_id: number }>;
+
+  pinChatMessage(
+    chatId: number | string,
+    messageId: number,
+    extra?: Record<string, unknown>,
+  ): Promise<boolean>;
+
+  unpinChatMessage(
+    chatId: number | string,
+    extra?: Record<string, unknown>,
+  ): Promise<boolean>;
+
+  editForumTopic(
+    chatId: number | string,
+    messageThreadId: number,
+    extra: { name?: string; icon_custom_emoji_id?: string },
+  ): Promise<boolean>;
+}
+
+// ─── TopicManager ──────────────────────────────────────────────────────────
+
+const TAG = '[Telegram/Topics]';
+
+export class TopicManager {
+  private api: TelegramApi;
+  private defaultChatId: string;
+
+  constructor(api: TelegramApi, defaultChatId: string) {
+    this.api = api;
+    this.defaultChatId = defaultChatId;
+  }
+
+  /**
+   * Resolve the chat ID: use the override if provided, otherwise the default.
+   */
+  private resolveChatId(chatId?: string): string {
+    return chatId ?? this.defaultChatId;
+  }
+
+  /**
+   * Create a new forum topic.
+   * Returns the thread ID and name of the newly created topic.
+   */
+  async createTopic(
+    name: string,
+    chatId?: string,
+  ): Promise<{ threadId: number; name: string }> {
+    const cid = this.resolveChatId(chatId);
+    console.log(`${TAG} Creating topic "${name}" in chat ${cid}`);
+    try {
+      const result = await this.api.createForumTopic(cid, name);
+      console.log(`${TAG} Created topic "${result.name}" → thread ${result.message_thread_id}`);
+      return { threadId: result.message_thread_id, name: result.name };
+    } catch (err) {
+      const message = `Failed to create topic "${name}" in chat ${cid}`;
+      console.error(`${TAG} ${message}:`, err);
+      throw new Error(`${TAG} ${message}: ${(err as Error).message}`);
+    }
+  }
+
+  /**
+   * Close (archive) a forum topic.
+   */
+  async closeTopic(threadId: number, chatId?: string): Promise<void> {
+    const cid = this.resolveChatId(chatId);
+    console.log(`${TAG} Closing topic ${threadId} in chat ${cid}`);
+    try {
+      await this.api.closeForumTopic(cid, threadId);
+    } catch (err) {
+      const message = `Failed to close topic ${threadId} in chat ${cid}`;
+      console.error(`${TAG} ${message}:`, err);
+      throw new Error(`${TAG} ${message}: ${(err as Error).message}`);
+    }
+  }
+
+  /**
+   * Reopen a previously closed forum topic.
+   */
+  async reopenTopic(threadId: number, chatId?: string): Promise<void> {
+    const cid = this.resolveChatId(chatId);
+    console.log(`${TAG} Reopening topic ${threadId} in chat ${cid}`);
+    try {
+      await this.api.reopenForumTopic(cid, threadId);
+    } catch (err) {
+      const message = `Failed to reopen topic ${threadId} in chat ${cid}`;
+      console.error(`${TAG} ${message}:`, err);
+      throw new Error(`${TAG} ${message}: ${(err as Error).message}`);
+    }
+  }
+
+  /**
+   * Delete a forum topic entirely.
+   */
+  async deleteTopic(threadId: number, chatId?: string): Promise<void> {
+    const cid = this.resolveChatId(chatId);
+    console.log(`${TAG} Deleting topic ${threadId} in chat ${cid}`);
+    try {
+      await this.api.deleteForumTopic(cid, threadId);
+    } catch (err) {
+      const message = `Failed to delete topic ${threadId} in chat ${cid}`;
+      console.error(`${TAG} ${message}:`, err);
+      throw new Error(`${TAG} ${message}: ${(err as Error).message}`);
+    }
+  }
+
+  /**
+   * Send a message to a specific topic. Returns the message_id of the sent message.
+   */
+  async sendToTopic(
+    threadId: number,
+    text: string,
+    opts?: { parseMode?: string; replyToMessageId?: number },
+    chatId?: string,
+  ): Promise<number> {
+    const cid = this.resolveChatId(chatId);
+    console.log(`${TAG} Sending message to topic ${threadId} in chat ${cid} (${text.length} chars)`);
+    try {
+      const extra: Record<string, unknown> = { message_thread_id: threadId };
+      if (opts?.parseMode) {
+        extra.parse_mode = opts.parseMode;
+      }
+      if (opts?.replyToMessageId) {
+        extra.reply_to_message_id = opts.replyToMessageId;
+      }
+      const result = await this.api.sendMessage(cid, text, extra);
+      return result.message_id;
+    } catch (err) {
+      const message = `Failed to send message to topic ${threadId} in chat ${cid}`;
+      console.error(`${TAG} ${message}:`, err);
+      throw new Error(`${TAG} ${message}: ${(err as Error).message}`);
+    }
+  }
+
+  /**
+   * Pin a message within a topic.
+   */
+  async pinInTopic(
+    threadId: number,
+    messageId: number,
+    chatId?: string,
+  ): Promise<void> {
+    const cid = this.resolveChatId(chatId);
+    console.log(`${TAG} Pinning message ${messageId} in topic ${threadId}, chat ${cid}`);
+    try {
+      await this.api.pinChatMessage(cid, messageId, {
+        message_thread_id: threadId,
+      });
+    } catch (err) {
+      const message = `Failed to pin message ${messageId} in topic ${threadId}, chat ${cid}`;
+      console.error(`${TAG} ${message}:`, err);
+      throw new Error(`${TAG} ${message}: ${(err as Error).message}`);
+    }
+  }
+
+  /**
+   * Unpin a message within a topic.
+   */
+  async unpinInTopic(
+    threadId: number,
+    messageId: number,
+    chatId?: string,
+  ): Promise<void> {
+    const cid = this.resolveChatId(chatId);
+    console.log(`${TAG} Unpinning message ${messageId} in topic ${threadId}, chat ${cid}`);
+    try {
+      await this.api.unpinChatMessage(cid, {
+        message_thread_id: threadId,
+        message_id: messageId,
+      });
+    } catch (err) {
+      const message = `Failed to unpin message ${messageId} in topic ${threadId}, chat ${cid}`;
+      console.error(`${TAG} ${message}:`, err);
+      throw new Error(`${TAG} ${message}: ${(err as Error).message}`);
+    }
+  }
+
+  /**
+   * Rename a forum topic.
+   */
+  async editTopicName(
+    threadId: number,
+    name: string,
+    chatId?: string,
+  ): Promise<void> {
+    const cid = this.resolveChatId(chatId);
+    console.log(`${TAG} Renaming topic ${threadId} to "${name}" in chat ${cid}`);
+    try {
+      await this.api.editForumTopic(cid, threadId, { name });
+    } catch (err) {
+      const message = `Failed to rename topic ${threadId} in chat ${cid}`;
+      console.error(`${TAG} ${message}:`, err);
+      throw new Error(`${TAG} ${message}: ${(err as Error).message}`);
+    }
+  }
+}


### PR DESCRIPTION
## Telegram Topic Management API

Pure abstraction over Telegram's forum topic operations. No Hermes dependencies.

### What's in it

`TopicManager` class wrapping Telegraf's API:

| Method | What it does |
|--------|-------------|
| `createTopic(name)` | Creates a forum topic, returns `{ threadId, name }` |
| `closeTopic(threadId)` | Archives a topic |
| `reopenTopic(threadId)` | Reopens an archived topic |
| `deleteTopic(threadId)` | Deletes a topic entirely |
| `sendToTopic(threadId, text)` | Sends a message to a topic via `message_thread_id` |
| `pinInTopic(threadId, msgId)` | Pins a message in a topic |
| `unpinInTopic(threadId, msgId)` | Unpins a message |
| `editTopicName(threadId, name)` | Renames a topic |

### Design choices

- **Structural `TelegramApi` interface** — decoupled from Telegraf's concrete types, easy to mock
- **Optional chatId override** on every method, with default fallback
- **Consistent error handling** — log with `[Telegram/Topics]` prefix, re-throw with context
- **Zero Hermes imports** — pure Telegram abstraction, testable in isolation

### Testing

Unit tests with vitest using a mock API that records all calls. Tests cover:
- Correct API method calls with correct params
- `message_thread_id` passed correctly for topic-scoped operations
- Default vs override chatId
- Error logging and re-throwing

### Dependency graph
```
This PR (#2)
  ↓
PR #4 (auto-create topics on channel creation) — future
```

No dependencies on other PRs. Can be merged independently.
