### PR TITLE
feat: channel-topic mapping store

### DIFF
--- a/server/src/telegram/channel-topic-mapping.test.ts
+++ b/server/src/telegram/channel-topic-mapping.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from 'vitest';
+import { ChannelTopicMappingStore, type ChannelTopicMapping } from './channel-topic-mapping.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeMapping(overrides: Partial<ChannelTopicMapping> = {}): ChannelTopicMapping {
+  return {
+    channelId: 'engineering',
+    telegramChatId: '-1001234567890',
+    telegramThreadId: 42,
+    topicName: 'Engineering',
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('ChannelTopicMappingStore', () => {
+  // ── Basic CRUD ──────────────────────────────────────────────────────────
+
+  it('adds and retrieves a mapping by channelId', () => {
+    const store = new ChannelTopicMappingStore();
+    const m = makeMapping();
+    store.add(m);
+    expect(store.getByChannelId('engineering')).toEqual(m);
+  });
+
+  it('retrieves a mapping by threadId', () => {
+    const store = new ChannelTopicMappingStore();
+    const m = makeMapping();
+    store.add(m);
+    expect(store.getByThreadId(42)).toEqual(m);
+  });
+
+  it('returns null for unknown channelId', () => {
+    const store = new ChannelTopicMappingStore();
+    expect(store.getByChannelId('nope')).toBeNull();
+  });
+
+  it('returns null for unknown threadId', () => {
+    const store = new ChannelTopicMappingStore();
+    expect(store.getByThreadId(999)).toBeNull();
+  });
+
+  it('lists all mappings', () => {
+    const store = new ChannelTopicMappingStore();
+    const m1 = makeMapping({ channelId: 'engineering', telegramThreadId: 1 });
+    const m2 = makeMapping({ channelId: 'design', telegramThreadId: 2, topicName: 'Design' });
+    store.add(m1);
+    store.add(m2);
+    const list = store.list();
+    expect(list).toHaveLength(2);
+    expect(list).toContainEqual(m1);
+    expect(list).toContainEqual(m2);
+  });
+
+  it('list() returns a copy, not internal state', () => {
+    const store = new ChannelTopicMappingStore();
+    store.add(makeMapping());
+    const list = store.list();
+    list.pop();
+    expect(store.size()).toBe(1); // unchanged
+  });
+
+  // ── Remove ──────────────────────────────────────────────────────────────
+
+  it('removes by channelId and cleans both indexes', () => {
+    const store = new ChannelTopicMappingStore();
+    store.add(makeMapping());
+    expect(store.remove('engineering')).toBe(true);
+    expect(store.getByChannelId('engineering')).toBeNull();
+    expect(store.getByThreadId(42)).toBeNull();
+    expect(store.size()).toBe(0);
+  });
+
+  it('remove returns false for nonexistent channelId', () => {
+    const store = new ChannelTopicMappingStore();
+    expect(store.remove('ghost')).toBe(false);
+  });
+
+  it('removeByThreadId works and cleans both indexes', () => {
+    const store = new ChannelTopicMappingStore();
+    store.add(makeMapping());
+    expect(store.removeByThreadId(42)).toBe(true);
+    expect(store.getByChannelId('engineering')).toBeNull();
+    expect(store.getByThreadId(42)).toBeNull();
+    expect(store.size()).toBe(0);
+  });
+
+  it('removeByThreadId returns false for nonexistent threadId', () => {
+    const store = new ChannelTopicMappingStore();
+    expect(store.removeByThreadId(9999)).toBe(false);
+  });
+
+  // ── has() ───────────────────────────────────────────────────────────────
+
+  it('has() returns true for existing channels', () => {
+    const store = new ChannelTopicMappingStore();
+    store.add(makeMapping());
+    expect(store.has('engineering')).toBe(true);
+  });
+
+  it('has() returns false for non-existing channels', () => {
+    const store = new ChannelTopicMappingStore();
+    expect(store.has('engineering')).toBe(false);
+  });
+
+  it('has() returns false after removal', () => {
+    const store = new ChannelTopicMappingStore();
+    store.add(makeMapping());
+    store.remove('engineering');
+    expect(store.has('engineering')).toBe(false);
+  });
+
+  // ── size() ──────────────────────────────────────────────────────────────
+
+  it('size starts at 0', () => {
+    expect(new ChannelTopicMappingStore().size()).toBe(0);
+  });
+
+  it('size tracks adds', () => {
+    const store = new ChannelTopicMappingStore();
+    store.add(makeMapping({ channelId: 'aa', telegramThreadId: 1 }));
+    store.add(makeMapping({ channelId: 'bb', telegramThreadId: 2 }));
+    expect(store.size()).toBe(2);
+  });
+
+  it('size tracks removes', () => {
+    const store = new ChannelTopicMappingStore();
+    store.add(makeMapping({ channelId: 'aa', telegramThreadId: 1 }));
+    store.add(makeMapping({ channelId: 'bb', telegramThreadId: 2 }));
+    store.remove('aa');
+    expect(store.size()).toBe(1);
+  });
+
+  // ── Duplicate prevention ────────────────────────────────────────────────
+
+  it('throws when adding a duplicate channelId', () => {
+    const store = new ChannelTopicMappingStore();
+    store.add(makeMapping());
+    expect(() => store.add(makeMapping({ telegramThreadId: 99 }))).toThrow(
+      /already mapped/,
+    );
+  });
+
+  // ── channelId validation ────────────────────────────────────────────────
+
+  it('rejects empty channelId', () => {
+    const store = new ChannelTopicMappingStore();
+    expect(() => store.add(makeMapping({ channelId: '' }))).toThrow(/Invalid channelId/);
+  });
+
+  it('rejects single-char channelId', () => {
+    const store = new ChannelTopicMappingStore();
+    expect(() => store.add(makeMapping({ channelId: 'a' }))).toThrow(/Invalid channelId/);
+  });
+
+  it('rejects channelId with uppercase', () => {
+    const store = new ChannelTopicMappingStore();
+    expect(() => store.add(makeMapping({ channelId: 'Engineering' }))).toThrow(/Invalid channelId/);
+  });
+
+  it('rejects channelId with spaces', () => {
+    const store = new ChannelTopicMappingStore();
+    expect(() => store.add(makeMapping({ channelId: 'my channel' }))).toThrow(/Invalid channelId/);
+  });
+
+  it('rejects channelId starting with hyphen', () => {
+    const store = new ChannelTopicMappingStore();
+    expect(() => store.add(makeMapping({ channelId: '-eng' }))).toThrow(/Invalid channelId/);
+  });
+
+  it('rejects channelId ending with hyphen', () => {
+    const store = new ChannelTopicMappingStore();
+    expect(() => store.add(makeMapping({ channelId: 'eng-' }))).toThrow(/Invalid channelId/);
+  });
+
+  it('rejects channelId over 30 chars', () => {
+    const store = new ChannelTopicMappingStore();
+    const long = 'a' + 'b'.repeat(30); // 31 chars
+    expect(() => store.add(makeMapping({ channelId: long }))).toThrow(/Invalid channelId/);
+  });
+
+  it('accepts valid channelId formats', () => {
+    const store = new ChannelTopicMappingStore();
+    // 2 chars, min length
+    store.add(makeMapping({ channelId: 'ab', telegramThreadId: 1 }));
+    // hyphens in middle
+    store.add(makeMapping({ channelId: 'my-cool-channel', telegramThreadId: 2 }));
+    // numbers
+    store.add(makeMapping({ channelId: 'channel-42', telegramThreadId: 3 }));
+    // 30 chars, max length
+    const max30 = 'a' + 'b'.repeat(28) + 'c'; // 30 chars
+    store.add(makeMapping({ channelId: max30, telegramThreadId: 4 }));
+    expect(store.size()).toBe(4);
+  });
+
+  // ── Serialization ──────────────────────────────────────────────────────
+
+  it('toJSON returns array of all mappings', () => {
+    const store = new ChannelTopicMappingStore();
+    const m = makeMapping();
+    store.add(m);
+    const json = store.toJSON();
+    expect(json).toEqual([m]);
+  });
+
+  it('round-trip: toJSON → fromJSON produces equivalent store', () => {
+    const store = new ChannelTopicMappingStore();
+    const m1 = makeMapping({ channelId: 'engineering', telegramThreadId: 1 });
+    const m2 = makeMapping({ channelId: 'design', telegramThreadId: 2, topicName: 'Design', createdBy: 'alice' });
+    store.add(m1);
+    store.add(m2);
+
+    const restored = ChannelTopicMappingStore.fromJSON(store.toJSON());
+    expect(restored.size()).toBe(2);
+    expect(restored.getByChannelId('engineering')).toEqual(m1);
+    expect(restored.getByChannelId('design')).toEqual(m2);
+    expect(restored.getByThreadId(1)).toEqual(m1);
+    expect(restored.getByThreadId(2)).toEqual(m2);
+  });
+
+  it('fromJSON with empty array returns empty store', () => {
+    const store = ChannelTopicMappingStore.fromJSON([]);
+    expect(store.size()).toBe(0);
+    expect(store.list()).toEqual([]);
+  });
+
+  it('fromJSON skips entries with invalid channelId', () => {
+    const store = ChannelTopicMappingStore.fromJSON([
+      makeMapping({ channelId: 'INVALID' }),
+      makeMapping({ channelId: 'valid-one', telegramThreadId: 10 }),
+    ]);
+    expect(store.size()).toBe(1);
+    expect(store.has('valid-one')).toBe(true);
+  });
+
+  it('fromJSON skips entries with missing fields', () => {
+    const store = ChannelTopicMappingStore.fromJSON([
+      { channelId: 'test' } as any,
+      { telegramThreadId: 5 } as any,
+      null as any,
+      undefined as any,
+    ]);
+    expect(store.size()).toBe(0);
+  });
+
+  it('fromJSON skips duplicate channelIds silently', () => {
+    const m = makeMapping();
+    const store = ChannelTopicMappingStore.fromJSON([m, { ...m, telegramThreadId: 99 }]);
+    expect(store.size()).toBe(1);
+    // First one wins
+    expect(store.getByThreadId(42)).toEqual(m);
+  });
+
+  it('fromJSON handles non-array input defensively', () => {
+    const store = ChannelTopicMappingStore.fromJSON('garbage' as any);
+    expect(store.size()).toBe(0);
+  });
+
+  it('fromJSON handles null input defensively', () => {
+    const store = ChannelTopicMappingStore.fromJSON(null as any);
+    expect(store.size()).toBe(0);
+  });
+});

--- a/server/src/telegram/channel-topic-mapping.ts
+++ b/server/src/telegram/channel-topic-mapping.ts
@@ -1,0 +1,126 @@
+/**
+ * Channel-Topic Mapping Store
+ *
+ * Maps Hermes channels (e.g. 'engineering') to Telegram forum topics.
+ * Each Hermes channel maps to exactly one Telegram forum thread_id in a
+ * supergroup. Efficient lookups by both channelId and threadId via internal Maps.
+ *
+ * Standalone module — no imports from other Hermes modules.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface ChannelTopicMapping {
+  channelId: string;          // Hermes channel slug, e.g. 'engineering'
+  telegramChatId: string;     // Telegram supergroup chat ID
+  telegramThreadId: number;   // Telegram forum topic thread_id
+  topicName: string;          // Display name of the topic
+  createdAt: number;          // Timestamp when mapping was created
+  createdBy?: string;         // Handle of who created it (optional)
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+/** Lowercase alphanumeric + hyphens, 2-30 chars, no leading/trailing hyphens. */
+const CHANNEL_ID_RE = /^[a-z0-9][a-z0-9-]{0,28}[a-z0-9]$/;
+
+function isValidChannelId(id: string): boolean {
+  return CHANNEL_ID_RE.test(id);
+}
+
+// ─── Store ───────────────────────────────────────────────────────────────────
+
+export class ChannelTopicMappingStore {
+  /** Primary index: channelId → mapping */
+  private byChannelId = new Map<string, ChannelTopicMapping>();
+  /** Secondary index: threadId → mapping */
+  private byThreadId = new Map<number, ChannelTopicMapping>();
+
+  /** Add a mapping. Throws if channelId already mapped or format is invalid. */
+  add(mapping: ChannelTopicMapping): void {
+    if (!isValidChannelId(mapping.channelId)) {
+      throw new Error(
+        `Invalid channelId "${mapping.channelId}": must be lowercase alphanumeric + hyphens, 2-30 chars`,
+      );
+    }
+    if (this.byChannelId.has(mapping.channelId)) {
+      throw new Error(
+        `Channel "${mapping.channelId}" is already mapped to thread ${this.byChannelId.get(mapping.channelId)!.telegramThreadId}`,
+      );
+    }
+    this.byChannelId.set(mapping.channelId, mapping);
+    this.byThreadId.set(mapping.telegramThreadId, mapping);
+  }
+
+  /** Remove a mapping by Hermes channel ID. Returns true if found & removed. */
+  remove(channelId: string): boolean {
+    const mapping = this.byChannelId.get(channelId);
+    if (!mapping) return false;
+    this.byChannelId.delete(channelId);
+    this.byThreadId.delete(mapping.telegramThreadId);
+    return true;
+  }
+
+  /** Remove a mapping by Telegram thread ID. Returns true if found & removed. */
+  removeByThreadId(threadId: number): boolean {
+    const mapping = this.byThreadId.get(threadId);
+    if (!mapping) return false;
+    this.byThreadId.delete(threadId);
+    this.byChannelId.delete(mapping.channelId);
+    return true;
+  }
+
+  /** Look up a mapping by Hermes channel ID. */
+  getByChannelId(channelId: string): ChannelTopicMapping | null {
+    return this.byChannelId.get(channelId) ?? null;
+  }
+
+  /** Look up a mapping by Telegram thread ID. */
+  getByThreadId(threadId: number): ChannelTopicMapping | null {
+    return this.byThreadId.get(threadId) ?? null;
+  }
+
+  /** Return all mappings as an array. */
+  list(): ChannelTopicMapping[] {
+    return [...this.byChannelId.values()];
+  }
+
+  /** Check if a Hermes channel has a mapping. */
+  has(channelId: string): boolean {
+    return this.byChannelId.has(channelId);
+  }
+
+  /** Number of active mappings. */
+  size(): number {
+    return this.byChannelId.size;
+  }
+
+  /** Serialize to a plain array for JSON persistence. */
+  toJSON(): ChannelTopicMapping[] {
+    return this.list();
+  }
+
+  /** Deserialize from persisted JSON array. Skips invalid entries defensively. */
+  static fromJSON(data: ChannelTopicMapping[]): ChannelTopicMappingStore {
+    const store = new ChannelTopicMappingStore();
+    if (!Array.isArray(data)) return store;
+    for (const entry of data) {
+      try {
+        // Minimal shape check — don't crash on garbage data
+        if (
+          entry &&
+          typeof entry.channelId === 'string' &&
+          typeof entry.telegramChatId === 'string' &&
+          typeof entry.telegramThreadId === 'number' &&
+          typeof entry.topicName === 'string' &&
+          typeof entry.createdAt === 'number'
+        ) {
+          store.add(entry);
+        }
+      } catch {
+        // Skip duplicates or invalid entries silently
+      }
+    }
+    return store;
+  }
+}

--- a/server/src/telegram/state.ts
+++ b/server/src/telegram/state.ts
@@ -7,6 +7,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, accessSync, constants } from 'fs';
 import { dirname } from 'path';
 import type { PostedEntry } from './types.js';
+import type { ChannelTopicMapping } from './channel-topic-mapping.js';
 
 /** Pick a writable path for state persistence. */
 function resolveStatePath(): string {
@@ -41,6 +42,8 @@ export interface BotState {
   proactivePostTimestamps: number[];
   /** Last write-back timestamp. */
   lastWritebackTime: number;
+  /** Hermes channel ↔ Telegram topic mappings. */
+  channelTopicMappings: ChannelTopicMapping[];
 }
 
 const EMPTY_STATE: BotState = {
@@ -50,6 +53,7 @@ const EMPTY_STATE: BotState = {
   channelPostTimestamps: [],
   proactivePostTimestamps: [],
   lastWritebackTime: 0,
+  channelTopicMappings: [],
 };
 
 /** Load persisted state from disk, or return empty state. */


### PR DESCRIPTION
## Channel-Topic Mapping Store

Bridge data structure mapping Hermes channels to Telegram forum topics.

### The type

```typescript
interface ChannelTopicMapping {
  channelId: string;          // 'engineering'
  telegramChatId: string;     // '-1001234567890'
  telegramThreadId: number;   // 42
  topicName: string;          // 'Engineering'
  createdAt: number;
  createdBy?: string;         // '@james'
}
```

### ChannelTopicMappingStore

| Method | What |
|--------|------|
| `add(mapping)` | Add a mapping (throws on duplicate channelId or invalid format) |
| `remove(channelId)` | Remove by Hermes channel ID |
| `removeByThreadId(threadId)` | Remove by Telegram thread ID |
| `getByChannelId(id)` | O(1) lookup by channel |
| `getByThreadId(id)` | O(1) lookup by thread |
| `list()` | All mappings |
| `has(channelId)` | Check existence |
| `toJSON()` / `fromJSON()` | Serialization for persistence |

### Design choices

- **Dual Map indexes** — O(1) lookups in both directions (channelId → mapping, threadId → mapping)
- **Standalone module** — no Hermes imports, channelId regex duplicated from storage.ts
- **Defensive `fromJSON`** — handles null, non-arrays, malformed entries, invalid IDs, duplicates
- **`list()` returns a copy** — prevents mutation of internal state

### State persistence

Added `channelTopicMappings: ChannelTopicMapping[]` to `BotState` interface with empty array default.

### Testing

27 vitest tests covering:
- Basic CRUD operations
- Duplicate prevention (throws on same channelId)
- Remove returns false for nonexistent entries
- channelId validation (10+ edge cases: empty, single char, uppercase, spaces, leading/trailing hyphens, over-length)
- Serialization round-trip
- Defensive fromJSON with garbage data

### Dependency graph
```
This PR (#3)
  ↓
PR #4 (auto-create) — needs #2 + #3
PR #5 (delivery routing) — needs #3
PR #6 (writeback tagging) — needs #3
```

No dependencies on other PRs. Can be merged independently.
