### PR TITLE
feat: add Telegram message capture pipeline (SQLite)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -25,9 +25,11 @@
     "firebase-admin": "^13.6.0",
     "jsonwebtoken": "^9.0.3",
     "resend": "^6.7.0",
+    "better-sqlite3": "^11.7.0",
     "telegraf": "^4.16.3"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.10.0",
     "tsx": "^4.7.0",

--- a/server/src/events.ts
+++ b/server/src/events.ts
@@ -4,7 +4,25 @@
  * The server pushes events (entry staged, entry published, chat message,
  * mention, etc.) and the agent polls them via the hermes_poll_events MCP tool.
  * Events are held in memory with a rolling window.
+ *
+ * Platform messages (platform_message, platform_mention) are also persisted
+ * to a local SQLite database via the message store for durable history.
  */
+
+import { initMessageStore, storeMessage as dbStoreMessage } from './message-store.js';
+
+// Lazily initialise the message store on first platform event
+let messageStoreReady = false;
+function ensureMessageStore(): void {
+  if (!messageStoreReady) {
+    try {
+      initMessageStore();
+      messageStoreReady = true;
+    } catch (err) {
+      console.error('[Events] Failed to initialise message store:', err);
+    }
+  }
+}
 
 export type EventType =
   | 'entry_staged'
@@ -40,6 +58,17 @@ export function pushEvent(type: EventType, data: Record<string, any>): HermesEve
   // Trim old events
   while (events.length > MAX_EVENTS) {
     events.shift();
+  }
+
+  // Persist platform messages to SQLite (fire-and-forget)
+  if (type === 'platform_message' || type === 'platform_mention') {
+    try {
+      ensureMessageStore();
+      dbStoreMessage(event);
+    } catch (err) {
+      // Never let a DB error break the event flow
+      console.error('[Events] Failed to persist message to SQLite:', err);
+    }
   }
 
   return event;

--- a/server/src/http.ts
+++ b/server/src/http.ts
@@ -28,6 +28,7 @@ import { createNotificationService, createSendGridClient, verifyUnsubscribeToken
 import { deliverEntry, getDefaultVisibility, canViewEntry, canView, normalizeEntry, isDefaultAiOnly, isEntryAiOnly, type DeliveryConfig } from './delivery.js';
 import { startTelegramBot, postToTelegram } from './telegram.js';
 import { pushEvent, getEventsSince, getLatestCursor, type EventType } from './events.js';
+import { queryMessages, getStats as getMessageStats, close as closeMessageStore } from './message-store.js';
 
 // Security: Check if a URL points to internal/private IP ranges
 function isInternalUrl(urlString: string): boolean {
@@ -697,6 +698,53 @@ export const SYSTEM_SKILLS: Skill[] = [
     instructions: '',
     handlerType: 'builtin',
     inputSchema: { type: 'object', properties: {} },
+    createdAt: 0,
+  },
+  {
+    id: 'system_hermes_query_messages',
+    name: 'hermes_query_messages',
+    description: 'Query the Telegram message history database. Supports flexible filtering by chat, sender, topic, and time range. Use action "query" to search messages or "stats" to get aggregate counts.',
+    instructions: '',
+    handlerType: 'builtin',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: ['query', 'stats'],
+          description: 'Action to perform: "query" returns matching messages, "stats" returns aggregate counts by chat/sender/topic.',
+        },
+        chat_id: {
+          type: 'string',
+          description: 'Filter by Telegram chat ID (optional).',
+        },
+        sender_id: {
+          type: 'string',
+          description: 'Filter by sender user ID (optional).',
+        },
+        topic_id: {
+          type: 'number',
+          description: 'Filter by forum topic/thread ID (optional).',
+        },
+        since: {
+          type: 'string',
+          description: 'Only return messages after this ISO 8601 timestamp (optional).',
+        },
+        until: {
+          type: 'string',
+          description: 'Only return messages before this ISO 8601 timestamp (optional).',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum messages to return (default 50, max 200).',
+        },
+        offset: {
+          type: 'number',
+          description: 'Offset for pagination (default 0).',
+        },
+      },
+      required: [],
+    },
     createdAt: 0,
   },
 ];
@@ -1391,7 +1439,7 @@ function createMCPServer(secretKey: string) {
           }
         }
         // Moderation tools: only show to moderators (or if no moderators configured, show to all)
-        if (['hermes_poll_events', 'hermes_review_staged', 'hermes_hold_entry', 'hermes_release_entry'].includes(skill.name)) {
+        if (['hermes_poll_events', 'hermes_review_staged', 'hermes_hold_entry', 'hermes_release_entry', 'hermes_query_messages'].includes(skill.name)) {
           if (!(storage instanceof StagedStorage)) return false;
           if (MODERATOR_HANDLES.size > 0 && (!handle || !MODERATOR_HANDLES.has(handle))) return false;
         }
@@ -3503,6 +3551,62 @@ HOLD:private business information`,
       const nextCursor = events[events.length - 1].id;
       return {
         content: [{ type: 'text' as const, text: `${events.length} events (cursor ${nextCursor}):\n\n${formatted}` }],
+      };
+    }
+
+    if (name === 'hermes_query_messages') {
+      const handle = await getHandle();
+      const isModerator = handle && MODERATOR_HANDLES.has(handle);
+      if (MODERATOR_HANDLES.size > 0 && !isModerator) {
+        return {
+          content: [{ type: 'text' as const, text: 'Only the Hermes agent can query messages.' }],
+          isError: true,
+        };
+      }
+
+      const params = args as {
+        action?: string;
+        chat_id?: string;
+        sender_id?: string;
+        topic_id?: number;
+        since?: string;
+        until?: string;
+        limit?: number;
+        offset?: number;
+      };
+
+      const action = params.action || 'query';
+
+      if (action === 'stats') {
+        const stats = getMessageStats();
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(stats, null, 2) }],
+        };
+      }
+
+      // Default: query
+      const messages = queryMessages({
+        chatId: params.chat_id,
+        senderId: params.sender_id,
+        topicId: params.topic_id,
+        since: params.since,
+        until: params.until,
+        limit: params.limit,
+        offset: params.offset,
+      });
+
+      if (messages.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'No messages found matching the query.' }],
+        };
+      }
+
+      const formatted = messages.map(m =>
+        `[${m.timestamp}] ${m.sender_name} (${m.sender_id}) in ${m.chat_id}${m.topic_id ? ` topic:${m.topic_id}` : ''}: ${m.text ?? `[${m.message_type}]`}`
+      ).join('\n');
+
+      return {
+        content: [{ type: 'text' as const, text: `${messages.length} messages:\n\n${formatted}` }],
       };
     }
 
@@ -7211,6 +7315,13 @@ server.listen(PORT, () => {
 
 process.on('SIGTERM', () => {
   console.log('[Shutdown] SIGTERM received, saving pending state...');
+
+  // Close the message store DB cleanly
+  try {
+    closeMessageStore();
+  } catch {
+    // Ignore — store may not have been initialised
+  }
 
   if (storage instanceof StagedStorage) {
     try {

--- a/server/src/message-store.ts
+++ b/server/src/message-store.ts
@@ -1,0 +1,254 @@
+/**
+ * SQLite-based message store for Telegram messages.
+ *
+ * Captures every platform_message and platform_mention event into a local
+ * SQLite database so we have durable, queryable history independent of
+ * the in-memory event queue's rolling window.
+ *
+ * Design choices:
+ *   - WAL mode for concurrent reads while writing
+ *   - Prepared statements for performance
+ *   - INSERT OR IGNORE for idempotent writes (unique on chat_id + message_id)
+ *   - Fire-and-forget from the event layer — never blocks the event flow
+ */
+
+import Database from 'better-sqlite3';
+import type BetterSqlite3 from 'better-sqlite3';
+import { existsSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+
+// ─── Schema ────────────────────────────────────────────────────────
+
+const CREATE_TABLE = `
+CREATE TABLE IF NOT EXISTS messages (
+  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+  message_id          INTEGER NOT NULL,
+  chat_id             TEXT    NOT NULL,
+  topic_id            INTEGER,
+  sender_id           TEXT    NOT NULL,
+  sender_name         TEXT    NOT NULL,
+  text                TEXT,
+  message_type        TEXT    NOT NULL DEFAULT 'text',
+  reply_to_message_id INTEGER,
+  timestamp           TEXT    NOT NULL,
+  raw_event           TEXT
+)`;
+
+const CREATE_UNIQUE_INDEX = `
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_chat_msg
+  ON messages (chat_id, message_id)`;
+
+const CREATE_INDEX_CHAT_TS = `
+CREATE INDEX IF NOT EXISTS idx_messages_chat_ts
+  ON messages (chat_id, timestamp)`;
+
+const CREATE_INDEX_SENDER = `
+CREATE INDEX IF NOT EXISTS idx_messages_sender
+  ON messages (sender_id)`;
+
+const CREATE_INDEX_TOPIC = `
+CREATE INDEX IF NOT EXISTS idx_messages_topic
+  ON messages (topic_id)`;
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+export interface MessageRow {
+  id: number;
+  message_id: number;
+  chat_id: string;
+  topic_id: number | null;
+  sender_id: string;
+  sender_name: string;
+  text: string | null;
+  message_type: string;
+  reply_to_message_id: number | null;
+  timestamp: string;
+  raw_event: string | null;
+}
+
+export interface QueryOptions {
+  chatId?: string;
+  senderId?: string;
+  topicId?: number;
+  since?: string;   // ISO 8601
+  until?: string;   // ISO 8601
+  limit?: number;   // default 50, max 200
+  offset?: number;
+}
+
+export interface MessageStats {
+  totalMessages: number;
+  byChatId: Array<{ chat_id: string; count: number }>;
+  bySender: Array<{ sender_id: string; sender_name: string; count: number }>;
+  byTopic: Array<{ topic_id: number | null; count: number }>;
+}
+
+export interface MessageStore {
+  storeMessage: (event: Record<string, any>) => void;
+  queryMessages: (opts: QueryOptions) => MessageRow[];
+  getStats: () => MessageStats;
+  close: () => void;
+}
+
+// ─── Prepared statements (lazily bound after DB open) ──────────────
+
+let db: BetterSqlite3.Database | null = null;
+let insertStmt: BetterSqlite3.Statement | null = null;
+
+// ─── Init ──────────────────────────────────────────────────────────
+
+function resolveDbPath(requestedPath?: string): string {
+  if (requestedPath) return requestedPath;
+
+  // Prefer /data (Docker volume mount) if it exists and is writable
+  try {
+    if (existsSync('/data')) {
+      return '/data/telegram-messages.db';
+    }
+  } catch {
+    // fall through
+  }
+  return './telegram-messages.db';
+}
+
+export function initMessageStore(dbPath?: string): MessageStore {
+  if (db) {
+    // Already initialised — return the existing store
+    return { storeMessage, queryMessages, getStats, close };
+  }
+
+  const resolved = resolveDbPath(dbPath);
+
+  // Ensure parent directory exists
+  const dir = dirname(resolved);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  db = new Database(resolved);
+
+  // Performance: WAL mode for concurrent reads
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+
+  // Create schema
+  db.exec(CREATE_TABLE);
+  db.exec(CREATE_UNIQUE_INDEX);
+  db.exec(CREATE_INDEX_CHAT_TS);
+  db.exec(CREATE_INDEX_SENDER);
+  db.exec(CREATE_INDEX_TOPIC);
+
+  // Prepare insert statement
+  insertStmt = db.prepare(`
+    INSERT OR IGNORE INTO messages
+      (message_id, chat_id, topic_id, sender_id, sender_name, text,
+       message_type, reply_to_message_id, timestamp, raw_event)
+    VALUES
+      (@message_id, @chat_id, @topic_id, @sender_id, @sender_name, @text,
+       @message_type, @reply_to_message_id, @timestamp, @raw_event)
+  `);
+
+  console.log(`[MessageStore] Opened SQLite database at ${resolved}`);
+
+  return { storeMessage, queryMessages, getStats, close };
+}
+
+// ─── Store ─────────────────────────────────────────────────────────
+
+export function storeMessage(event: Record<string, any>): void {
+  if (!db || !insertStmt) return;
+
+  const data = event.data ?? event;
+
+  insertStmt.run({
+    message_id: data.message_id ?? 0,
+    chat_id: String(data.chat_id ?? ''),
+    topic_id: data.topic_id ?? null,
+    sender_id: String(data.sender_id ?? ''),
+    sender_name: String(data.sender_name ?? ''),
+    text: data.text ?? null,
+    message_type: data.message_type ?? 'text',
+    reply_to_message_id: data.reply_to_message_id ?? null,
+    timestamp: data.timestamp ?? new Date().toISOString(),
+    raw_event: JSON.stringify(event),
+  });
+}
+
+// ─── Query ─────────────────────────────────────────────────────────
+
+export function queryMessages(opts: QueryOptions): MessageRow[] {
+  if (!db) return [];
+
+  const conditions: string[] = [];
+  const params: Record<string, any> = {};
+
+  if (opts.chatId) {
+    conditions.push('chat_id = @chatId');
+    params.chatId = opts.chatId;
+  }
+  if (opts.senderId) {
+    conditions.push('sender_id = @senderId');
+    params.senderId = opts.senderId;
+  }
+  if (opts.topicId !== undefined && opts.topicId !== null) {
+    conditions.push('topic_id = @topicId');
+    params.topicId = opts.topicId;
+  }
+  if (opts.since) {
+    conditions.push('timestamp >= @since');
+    params.since = opts.since;
+  }
+  if (opts.until) {
+    conditions.push('timestamp <= @until');
+    params.until = opts.until;
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+  const limit = Math.min(opts.limit ?? 50, 200);
+  const offset = opts.offset ?? 0;
+
+  const sql = `SELECT * FROM messages ${where} ORDER BY timestamp DESC, id DESC LIMIT @limit OFFSET @offset`;
+  const stmt = db.prepare(sql);
+
+  return stmt.all({ ...params, limit, offset }) as MessageRow[];
+}
+
+// ─── Stats ─────────────────────────────────────────────────────────
+
+export function getStats(): MessageStats {
+  if (!db) {
+    return { totalMessages: 0, byChatId: [], bySender: [], byTopic: [] };
+  }
+
+  const totalRow = db.prepare('SELECT COUNT(*) as count FROM messages').get() as { count: number };
+
+  const byChatId = db.prepare(
+    'SELECT chat_id, COUNT(*) as count FROM messages GROUP BY chat_id ORDER BY count DESC LIMIT 50'
+  ).all() as Array<{ chat_id: string; count: number }>;
+
+  const bySender = db.prepare(
+    'SELECT sender_id, sender_name, COUNT(*) as count FROM messages GROUP BY sender_id ORDER BY count DESC LIMIT 50'
+  ).all() as Array<{ sender_id: string; sender_name: string; count: number }>;
+
+  const byTopic = db.prepare(
+    'SELECT topic_id, COUNT(*) as count FROM messages GROUP BY topic_id ORDER BY count DESC LIMIT 50'
+  ).all() as Array<{ topic_id: number | null; count: number }>;
+
+  return {
+    totalMessages: totalRow.count,
+    byChatId,
+    bySender,
+    byTopic,
+  };
+}
+
+// ─── Close ─────────────────────────────────────────────────────────
+
+export function close(): void {
+  if (db) {
+    db.close();
+    db = null;
+    insertStmt = null;
+    console.log('[MessageStore] Closed SQLite database');
+  }
+}


### PR DESCRIPTION
## Telegram Message Capture Pipeline

Adds SQLite-based persistent storage for all Telegram messages, captured server-side in the event queue layer. This gives us durable, queryable message history beyond the in-memory event queue's rolling 1000-event window.

### What it does

Every `platform_message` and `platform_mention` event that flows through `pushEvent()` is now also written to a local SQLite database. The write is fire-and-forget — wrapped in try/catch so a DB error never breaks the event flow.

### Schema

```sql
CREATE TABLE messages (
  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
  message_id          INTEGER NOT NULL,       -- Telegram message ID
  chat_id             TEXT    NOT NULL,       -- chat ID (text for negative bigints)
  topic_id            INTEGER,                -- forum topic/thread ID
  sender_id           TEXT    NOT NULL,       -- user ID
  sender_name         TEXT    NOT NULL,
  text                TEXT,                   -- nullable for non-text messages
  message_type        TEXT    NOT NULL DEFAULT 'text',
  reply_to_message_id INTEGER,
  timestamp           TEXT    NOT NULL,       -- ISO 8601
  raw_event           TEXT                    -- full event JSON
);

-- Indexes
UNIQUE INDEX ON (chat_id, message_id)       -- dedup
INDEX ON (chat_id, timestamp)               -- range queries
INDEX ON (sender_id)                        -- per-user queries
INDEX ON (topic_id)                         -- thread queries
```

### How it wires in

- **`server/src/message-store.ts`** — New module. Opens/creates SQLite DB (WAL mode, prepared statements). Exports `initMessageStore`, `storeMessage`, `queryMessages`, `getStats`, `close`.
- **`server/src/events.ts`** — After pushing to the in-memory queue, calls `storeMessage()` for platform events. Lazy init on first event. Try/catch ensures DB errors never break event processing.
- **`server/src/http.ts`** — Adds `hermes_query_messages` MCP tool (moderator-only). Clean DB shutdown on SIGTERM.
- **`server/package.json`** — Adds `better-sqlite3` and `@types/better-sqlite3`.

### MCP Tool: `hermes_query_messages`

| Parameter | Type | Description |
|-----------|------|-------------|
| action | `query` \| `stats` | Query messages or get aggregate stats |
| chat_id | string | Filter by chat |
| sender_id | string | Filter by sender |
| topic_id | number | Filter by forum topic |
| since | string | ISO 8601 start time |
| until | string | ISO 8601 end time |
| limit | number | Max results (default 50, max 200) |
| offset | number | Pagination offset |

### Design decisions

- **INSERT OR IGNORE** for idempotent writes (unique constraint on chat_id + message_id)
- **WAL mode** for concurrent reads during writes
- **Lazy initialization** — DB is only opened when the first platform message arrives
- **Default path**: `/data/telegram-messages.db` (Docker volume), fallback `./telegram-messages.db`
- **Additive only** — no existing functionality is modified or broken