### PR TITLE
matrix: auto-rotate outbound megolm sessions on sync recovery + periodic

### DIFF
--- a/server/src/platform/matrix.ts
+++ b/server/src/platform/matrix.ts
@@ -673,6 +673,13 @@ export class MatrixPlatform implements Platform {
   // not auto-rotate on connection recovery.
   private installMegolmAutoRotation(): void {
     if (!this.client) return;
+    // Test-only kill switch. When set, behaves as if this method was
+    // never added — used by tests/federation-repro to verify the bug
+    // reproduces without the rotation.
+    if (process.env.MATRIX_DISABLE_MEGOLM_AUTOROTATE === '1') {
+      console.log('[Matrix] megolm auto-rotation DISABLED (MATRIX_DISABLE_MEGOLM_AUTOROTATE=1)');
+      return;
+    }
 
     // Sync-recovery hook: any transition INTO 'SYNCING' from a non-syncing
     // state signals "we just reconnected." Trigger an immediate rotation

--- a/server/src/platform/matrix.ts
+++ b/server/src/platform/matrix.ts
@@ -407,6 +407,15 @@ export class MatrixPlatform implements Platform {
   private processedMessageEvents = new Set<string>();
   private pendingInviteJoins = new Set<string>();
   private joinedInviteRooms = new Set<string>();
+  // Megolm session rotation. We discard outbound sessions periodically and
+  // on detected sync recovery so federation hiccups (which can drop the
+  // m.room_key to-device EDU that distributes a session) self-heal: the
+  // next outbound message creates a fresh session and a fresh m.room_key
+  // distribution. Without this, a session created during a federation
+  // outage stays undecryptable for receivers indefinitely. See incident
+  // 2026-05-09 (shape-rotator-matrix repo, docs/incidents).
+  private megolmRotationTimer: NodeJS.Timeout | null = null;
+  private lastSyncState: string | null = null;
 
   constructor(config: MatrixPlatformConfig) {
     this.config = config;
@@ -570,6 +579,8 @@ export class MatrixPlatform implements Platform {
     // Start syncing (must happen before cross-signing bootstrap so we can query our own keys)
     await this.client.startClient({ initialSyncLimit: 0 });
 
+    this.installMegolmAutoRotation();
+
     // Install the hand-rolled SAS verification manager. Replaces the SDK's
     // broken VerificationRequest/Verifier high-level API which produces MACs
     // that Continuwuity rejects with m.mismatched_sas. Ports Andrew Miller's
@@ -625,9 +636,93 @@ export class MatrixPlatform implements Platform {
     } catch (err: any) {
       console.warn('[Matrix] Final crypto flush failed:', err.message);
     }
+    if (this.megolmRotationTimer) {
+      clearInterval(this.megolmRotationTimer);
+      this.megolmRotationTimer = null;
+    }
     if (this.client) {
       this.client.stopClient();
       this.client = null;
+    }
+  }
+
+  // ── Megolm auto-rotation ─────────────────────────────────
+  //
+  // Bots that send into encrypted rooms across federation are vulnerable to
+  // a silent-decrypt-failure mode: if the m.room_key to-device EDU that
+  // distributes a freshly-created outbound megolm session is dropped (e.g.
+  // by a federation hiccup, target homeserver outage, or backed-off
+  // federation queue), receivers never get the session key and *every*
+  // subsequent message in that session is undecryptable for them. The
+  // protocol-level recovery is m.room_key_request → m.forwarded_room_key,
+  // but matrix-rust-sdk gates that on cross-signing trust by default and
+  // bot-to-user is rarely cross-signed; the request is silently ignored
+  // and the room stays broken until manual intervention.
+  //
+  // Mitigation: rotate outbound megolm sessions periodically and on
+  // detected sync-recovery transitions. After rotation, the next outbound
+  // message creates a fresh session whose m.room_key distribution will
+  // succeed if federation is healthy. Old undecryptable messages stay
+  // undecryptable, but the room is unwedged for messages going forward.
+  //
+  // History: shape-rotator-matrix incident 2026-05-09 — 6+ conduwuit
+  // restarts in 5h backed up matrix.org's federation queue, dropped the
+  // m.room_key to-device for both Router (this bot) and claw-teedah-2.
+  // claw-teedah-2 (mautrix-python) auto-recovered within hours; Router
+  // stayed broken until manual intervention because matrix-rust-sdk does
+  // not auto-rotate on connection recovery.
+  private installMegolmAutoRotation(): void {
+    if (!this.client) return;
+
+    // Sync-recovery hook: any transition INTO 'SYNCING' from a non-syncing
+    // state signals "we just reconnected." Trigger an immediate rotation
+    // for all encrypted rooms the bot is in.
+    this.client.on(ClientEvent.Sync, (state: string) => {
+      const prev = this.lastSyncState;
+      this.lastSyncState = state;
+      if (state === 'SYNCING' && prev && prev !== 'SYNCING' && prev !== 'PREPARED') {
+        console.log(`[Matrix] sync recovered (${prev} → ${state}); rotating megolm sessions`);
+        this.rotateAllOutboundMegolmSessions().catch((err: any) => {
+          console.warn('[Matrix] post-recovery megolm rotation failed:', err.message);
+        });
+      }
+    });
+
+    // Periodic rotation (default 4h). Bounded by the lower of (a) the
+    // longest plausible federation outage we can tolerate before a
+    // receiver notices and (b) the matrix-rust-sdk default rotation
+    // interval (7 days / 100 messages, far too long for bots).
+    const intervalMs = Number(process.env.MATRIX_MEGOLM_ROTATION_INTERVAL_MS || 4 * 60 * 60 * 1000);
+    if (intervalMs > 0) {
+      this.megolmRotationTimer = setInterval(() => {
+        this.rotateAllOutboundMegolmSessions().catch((err: any) => {
+          console.warn('[Matrix] periodic megolm rotation failed:', err.message);
+        });
+      }, intervalMs);
+      console.log(`[Matrix] megolm auto-rotation installed (every ${intervalMs / 1000}s + on sync recovery)`);
+    }
+  }
+
+  private async rotateAllOutboundMegolmSessions(): Promise<void> {
+    const client = this.client;
+    if (!client) return;
+    const crypto = client.getCrypto();
+    if (!crypto) return;
+    const rooms = client.getRooms().filter(r => r.hasEncryptionStateEvent());
+    let rotated = 0;
+    for (const room of rooms) {
+      try {
+        // forceDiscardSession is the supported matrix-js-sdk API for
+        // dropping the cached outbound megolm session. Next send will
+        // create a fresh one and re-distribute keys to all joined devices.
+        await crypto.forceDiscardSession(room.roomId);
+        rotated++;
+      } catch (err: any) {
+        console.warn(`[Matrix] forceDiscardSession failed for ${room.roomId}: ${err.message}`);
+      }
+    }
+    if (rotated > 0) {
+      console.log(`[Matrix] discarded ${rotated} outbound megolm session(s)`);
     }
   }
 

--- a/tests/federation-repro/.gitignore
+++ b/tests/federation-repro/.gitignore
@@ -1,0 +1,6 @@
+certs/*.key
+certs/*.pem
+certs/*.crt
+certs/*.csr
+certs/*.cnf
+certs/*.srl

--- a/tests/federation-repro/README.md
+++ b/tests/federation-repro/README.md
@@ -1,0 +1,55 @@
+# Federation repro harness — megolm rotation bug
+
+Reproduces the silent-decrypt-failure bug Router exhibits when a federation
+hiccup drops the `m.room_key` to-device EDU that distributes a freshly-created
+outbound megolm session.
+
+## Status
+
+- [x] Phase 1 — two continuwuity HSes federate locally over TLS (this commit)
+- [ ] Phase 2 — bot on hs-a + user on hs-b complete an encrypted-room baseline
+- [ ] Phase 3 — federation interruption simulation (drop m.room_key in flight)
+- [ ] Phase 4 — assert bug without fix, recovery with fix
+
+## Topology
+
+```
+peer query hs-a:8448 ──TLS──▶ hs-a (nginx) ──HTTP──▶ hs-a-core (continuwuity :6167)
+peer query hs-b:8448 ──TLS──▶ hs-b (nginx) ──HTTP──▶ hs-b-core (continuwuity :6167)
+```
+
+Both HSes trust a shared self-signed CA generated under `certs/` so federation
+TLS handshakes succeed without going through public DNS / Let's Encrypt.
+
+## Use
+
+```bash
+# 1. generate the shared CA + per-HS certs (idempotent; skips if present)
+bash scripts/gen-certs.sh
+
+# 2. bring up both homeservers + their TLS proxies
+docker compose up -d hs-a-core hs-b-core hs-a hs-b
+
+# 3. sanity check
+curl -fsS http://localhost:8001/_matrix/client/versions | head -c 80
+curl -fsS http://localhost:8002/_matrix/client/versions | head -c 80
+
+# 4. cross-HS federation check (curlimages/curl on the fednet bridge)
+docker run --rm --network federation-repro_fednet \
+  -v "$(pwd)/certs:/certs:ro" curlimages/curl \
+  --cacert /certs/ca.pem -fsS https://hs-b:8448/_matrix/federation/v1/version
+
+# 5. tear down (also drops volumes)
+docker compose down -v
+```
+
+## Notes
+
+- continuwuity 0.5.8 is built without `direct_tls`, so each HS sits behind an
+  nginx TLS proxy. The proxy listens on port 8448 (federation default) and
+  forwards `/_matrix/` traffic to conduwuit's plain-HTTP port. Each HS also
+  serves a `.well-known/matrix/server` from the proxy.
+- `SSL_CERT_FILE=/certs/ca.pem` is set on the conduwuit containers so their
+  outbound federation client trusts the test CA when verifying peer certs.
+- The peers' federation hostname (`hs-a`, `hs-b`) is just the docker network
+  alias of the proxy. No DNS dance needed inside `fednet`.

--- a/tests/federation-repro/README.md
+++ b/tests/federation-repro/README.md
@@ -6,10 +6,52 @@ outbound megolm session.
 
 ## Status
 
-- [x] Phase 1 — two continuwuity HSes federate locally over TLS (this commit)
-- [ ] Phase 2 — bot on hs-a + user on hs-b complete an encrypted-room baseline
-- [ ] Phase 3 — federation interruption simulation (drop m.room_key in flight)
-- [ ] Phase 4 — assert bug without fix, recovery with fix
+- [x] Phase 1 — two continuwuity HSes federate locally over TLS
+- [x] Phase 2 — bot on hs-a + user on hs-b complete an encrypted-room baseline
+- [x] Phase 3 — federation interruption simulation (MITM drops m.direct_to_device)
+- [x] Phase 4 — bug reproduces; fix evaluation in progress (see findings below)
+
+## Findings (current)
+
+`bash scripts/run-baseline.sh` passes — federated encrypted round-trip is working baseline.
+
+`bash scripts/run-bug.sh` (FIX=disabled, default with the patch's
+`MATRIX_DISABLE_MEGOLM_AUTOROTATE=1` kill switch) **reproduces the bug
+exactly**:
+
+1. baseline message decrypts ok
+2. bot rotates outbound megolm session, sends "stuck-1" — m.room_key
+   to-device gets dropped by the MITM, user can't decrypt
+3. bot sends "stuck-2" reusing same broken session — also undecryptable
+4. MITM disarmed (federation healthy again)
+5. bot sends "post-restore" reusing the broken session — STILL
+   undecryptable, because matrix-js-sdk thinks the m.room_key was
+   delivered (the MITM returned 200, just with the EDU stripped) and
+   doesn't retry
+6. Wait past the bot's periodic-rotation interval, send "after-rotation":
+   - WITHOUT FIX: stays undecryptable indefinitely. Confirmed.
+
+`bash scripts/run-bug.sh` with FIX=enabled (the patch active): the
+`installMegolmAutoRotation` periodic timer fires as designed
+(visible: `[Matrix] discarded N outbound megolm session(s)` log
+lines), AND matrix-js-sdk's own log shows
+`[<roomId> encryption] Discarded existing group session`. **But the
+user still can't decrypt the after-rotation message.**
+
+So the patch fires the discard but the room doesn't actually recover.
+Hypothesis: `forceDiscardSession` evicts the cached outbound megolm
+session, which causes the next send to create a fresh session — but
+matrix-rust-sdk doesn't re-establish the underlying olm channels
+with the recipient devices that may have been corrupted by the MITM
+window. Need either (a) `crypto.shareGroupSession()` after discard,
+(b) a `/keys/claim` for users in the room to refresh olm sessions,
+or (c) a different force-reshare API I haven't found yet.
+
+**Conclusion: the patch as written needs more work before it can be
+merged.** PR #31 should stay draft until either the patch is
+revised to actually recover the room, or the test is revised to show
+where the patch's value actually lives (e.g. avoiding the broken
+state in the first place rather than recovering from it).
 
 ## Phase 2 plan (next commit)
 

--- a/tests/federation-repro/README.md
+++ b/tests/federation-repro/README.md
@@ -11,6 +11,60 @@ outbound megolm session.
 - [ ] Phase 3 — federation interruption simulation (drop m.room_key in flight)
 - [ ] Phase 4 — assert bug without fix, recovery with fix
 
+## Phase 2 plan (next commit)
+
+Goal: prove federation-side crypto round-trip works when nothing is broken.
+Without this baseline, phase 3's "we broke it" assertion is meaningless.
+
+- `tests/federation-repro/repro/bot.ts` — uses `MatrixPlatform` from
+  `server/src/platform/matrix.ts` pointed at `http://localhost:8001`.
+  Registers fresh on hs-a with the `fedrepro` token, joins/creates an
+  encrypted room, exposes a small CLI surface for the test driver.
+- `tests/federation-repro/repro/user.py` — uses `matrix-nio` (or `mautrix`)
+  pointed at `http://localhost:8002`. Registers on hs-b, accepts the
+  invite from the bot's room, syncs, prints decrypted message bodies.
+- `tests/federation-repro/repro/run-baseline.sh` — orchestrates: start
+  bot, register user, send invite, accept, send "baseline ping", verify
+  user.py prints the decrypted ping.
+
+Commit gate: a clean "baseline ping → received as decrypted text"
+round-trip across the federation, repeatable from `make baseline` (or
+similar entry point).
+
+## Phase 3 plan
+
+Goal: simulate "m.room_key for a freshly-created outbound megolm session
+got dropped in transit," matching the production failure mode.
+
+- Insert a small HTTP MITM (e.g. a Node script using `http-mitm-proxy`
+  or a stripped-down `mitmproxy` script) on the federation path between
+  hs-a-proxy and hs-b. Configure hs-a-core's outbound federation to
+  route through it (probably via docker network alias rebind so the
+  proxy intercepts hs-a → hs-b traffic).
+- Add a kill-switch: when armed, the MITM drops POST
+  `/_matrix/federation/v1/send/{txnId}` requests whose body contains
+  `"m.room_key"` to-device events. (Specifically: filter the EDUs
+  inside `edus[]`, drop only the to-device ones for the test recipient,
+  pass the rest through. So sync still works, only the key share is
+  dropped.)
+- Test driver: arm the MITM, force a session rotation on the bot
+  (`forceDiscardSession()` then send), un-arm. Verify the m.room_key
+  for that session never reached hs-b's queue.
+
+## Phase 4 plan
+
+Goal: prove the rotation patch unwedges things.
+
+- Without the patch (a separate compiled artifact, e.g. a flag-gated
+  "noop installMegolmAutoRotation"): after phase 3, every subsequent
+  bot send is undecryptable for the user, indefinitely.
+- With the patch: trigger a sync interruption (briefly stop hs-a-core,
+  restart). On reconnect, the rotation hook fires, the bot's next
+  message uses a fresh outbound session, and the m.room_key for that
+  session delivers cleanly (federation healthy now). User decrypts.
+- The test asserts: undecryptable count before fix > 0,
+  undecryptable count after fix === 0 (modulo the exact stuck batch).
+
 ## Topology
 
 ```

--- a/tests/federation-repro/docker-compose.yml
+++ b/tests/federation-repro/docker-compose.yml
@@ -64,15 +64,47 @@ services:
       - hs-b-data:/var/lib/conduwuit
       - ./certs:/certs:ro
 
-  hs-b:
+  hs-b-real:
+    # The "real" TLS proxy for hs-b. Renamed from `hs-b` so the MITM
+    # below can take that alias and sit in front. When phase 3's MITM
+    # is disabled, hs-b-real plays the same role as hs-a (plain pass-
+    # through TLS termination).
     image: nginx:alpine
     networks:
       fednet:
-        aliases: [hs-b]
+        aliases: [hs-b-real]
     depends_on: [hs-b-core]
     volumes:
       - ./scripts/nginx-hs-b.conf:/etc/nginx/conf.d/default.conf:ro
       - ./certs:/certs:ro
+
+  hs-b:
+    # Federation MITM. By default, pass-through (no traffic is altered).
+    # Set MITM_DROP_TYPES (comma-separated) to selectively drop EDUs of
+    # given to-device types from POST /_matrix/federation/v1/send/*
+    # requests in flight.
+    image: node:24-alpine
+    networks:
+      fednet:
+        aliases: [hs-b]
+    depends_on: [hs-b-real]
+    environment:
+      MITM_LISTEN_PORT: "8448"
+      MITM_UPSTREAM_HOST: hs-b-real
+      MITM_UPSTREAM_PORT: "8448"
+      MITM_TLS_CERT: /certs/hs-b.crt
+      MITM_TLS_KEY:  /certs/hs-b.key
+      MITM_UPSTREAM_CA: /certs/ca.pem
+      MITM_DROP_TYPES: ${MITM_DROP_TYPES:-}
+      MITM_LOG_FILE: /shared/mitm.jsonl
+    volumes:
+      - ./certs:/certs:ro
+      - ./repro:/app:ro
+      - mitm-shared:/shared
+    working_dir: /app
+    command: ["node", "mitm.js"]
+    ports:
+      - "8403:8448"
 
 networks:
   fednet:
@@ -81,3 +113,4 @@ networks:
 volumes:
   hs-a-data:
   hs-b-data:
+  mitm-shared:

--- a/tests/federation-repro/docker-compose.yml
+++ b/tests/federation-repro/docker-compose.yml
@@ -96,6 +96,7 @@ services:
       MITM_TLS_KEY:  /certs/hs-b.key
       MITM_UPSTREAM_CA: /certs/ca.pem
       MITM_DROP_TYPES: ${MITM_DROP_TYPES:-}
+      MITM_LOG_BODIES: ${MITM_LOG_BODIES:-}
       MITM_LOG_FILE: /shared/mitm.jsonl
     volumes:
       - ./certs:/certs:ro

--- a/tests/federation-repro/docker-compose.yml
+++ b/tests/federation-repro/docker-compose.yml
@@ -1,0 +1,83 @@
+# Two-homeserver federation harness for reproducing the megolm
+# rotation bug Router exhibits when a federation hiccup drops the
+# m.room_key to-device EDU.
+#
+# Topology (over docker network `fednet`):
+#
+#   peer queries hs-a:8448 → hs-a-proxy (nginx, terminates TLS) → hs-a-core:6167 (HTTP)
+#   peer queries hs-b:8448 → hs-b-proxy (nginx, terminates TLS) → hs-b-core:6167 (HTTP)
+#
+# Peers see the homeserver as hostname `hs-a` (default federation port 8448).
+# Each homeserver trusts the shared test CA for outbound federation.
+services:
+  hs-a-core:
+    image: ghcr.io/continuwuity/continuwuity:latest
+    networks:
+      fednet:
+        aliases: [hs-a-core]
+    ports:
+      - "8001:6167"  # client API exposed for tests
+    environment:
+      CONDUWUIT_SERVER_NAME: hs-a
+      CONDUWUIT_DATABASE_BACKEND: rocksdb
+      CONDUWUIT_DATABASE_PATH: /var/lib/conduwuit
+      CONDUWUIT_ADDRESS: "0.0.0.0"
+      CONDUWUIT_PORT: "6167"
+      CONDUWUIT_ALLOW_REGISTRATION: "true"
+      CONDUWUIT_REGISTRATION_TOKEN: "fedrepro"
+      CONDUWUIT_ALLOW_FEDERATION: "true"
+      CONDUWUIT_LOG: "info,conduwuit=debug"
+      SSL_CERT_FILE: "/certs/ca.pem"
+    volumes:
+      - hs-a-data:/var/lib/conduwuit
+      - ./certs:/certs:ro
+
+  hs-a:
+    image: nginx:alpine
+    networks:
+      fednet:
+        aliases: [hs-a]
+    depends_on: [hs-a-core]
+    volumes:
+      - ./scripts/nginx-hs-a.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./certs:/certs:ro
+
+  hs-b-core:
+    image: ghcr.io/continuwuity/continuwuity:latest
+    networks:
+      fednet:
+        aliases: [hs-b-core]
+    ports:
+      - "8002:6167"
+    environment:
+      CONDUWUIT_SERVER_NAME: hs-b
+      CONDUWUIT_DATABASE_BACKEND: rocksdb
+      CONDUWUIT_DATABASE_PATH: /var/lib/conduwuit
+      CONDUWUIT_ADDRESS: "0.0.0.0"
+      CONDUWUIT_PORT: "6167"
+      CONDUWUIT_ALLOW_REGISTRATION: "true"
+      CONDUWUIT_REGISTRATION_TOKEN: "fedrepro"
+      CONDUWUIT_ALLOW_FEDERATION: "true"
+      CONDUWUIT_LOG: "info,conduwuit=debug"
+      SSL_CERT_FILE: "/certs/ca.pem"
+    volumes:
+      - hs-b-data:/var/lib/conduwuit
+      - ./certs:/certs:ro
+
+  hs-b:
+    image: nginx:alpine
+    networks:
+      fednet:
+        aliases: [hs-b]
+    depends_on: [hs-b-core]
+    volumes:
+      - ./scripts/nginx-hs-b.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./certs:/certs:ro
+
+networks:
+  fednet:
+    driver: bridge
+
+volumes:
+  hs-a-data:
+  hs-b-data:

--- a/tests/federation-repro/repro/bot.ts
+++ b/tests/federation-repro/repro/bot.ts
@@ -1,0 +1,117 @@
+/**
+ * Repro bot — runs Router's MatrixPlatform pointed at hs-a, then
+ * accepts driver commands on stdin. The driver is run-baseline.sh /
+ * run-repro.sh which orchestrates the full scenario across both HSes.
+ *
+ * Stdin protocol (one JSON object per line):
+ *   {"cmd": "create-room"}              → creates an encrypted room, prints room_id
+ *   {"cmd": "invite", "user": "..."}    → invites mxid to the current room
+ *   {"cmd": "send", "text": "..."}      → sends a text message
+ *   {"cmd": "rotate"}                   → forceDiscardSession on the current room
+ *   {"cmd": "exit"}
+ *
+ * Replies via stdout, also one JSON object per line:
+ *   {"ok": true, "room_id": "..."} | {"ok": true, "event_id": "..."} | {"err": "..."}
+ *
+ * The driver matches request/reply by sequence — each reply corresponds
+ * to the most recent command. Bot state (current room id) is implicit.
+ */
+import * as readline from 'node:readline';
+import * as fs from 'node:fs';
+import { MatrixPlatform } from '../../../server/src/platform/matrix.js';
+
+const SERVER_URL  = process.env.FED_REPRO_HS_A_URL  || 'http://localhost:8001';
+const SERVER_NAME = process.env.FED_REPRO_HS_A_NAME || 'hs-a';
+const REG_TOKEN   = process.env.FED_REPRO_TOKEN     || 'fedrepro';
+const BOT_HANDLE  = process.env.FED_REPRO_BOT_HANDLE || `repro-bot-${process.pid}`;
+const BOT_SECRET  = process.env.FED_REPRO_BOT_SECRET || `repro-bot-secret-${process.pid}`;
+// matrix-js-sdk + rust crypto spam stdout heavily during bootstrap.
+// Use a separate file for JSON replies so the driver can read them
+// without filtering SDK noise.
+const REPLY_FILE  = process.env.FED_REPRO_BOT_REPLY_FILE || '/tmp/fed-repro-bot-reply.jsonl';
+
+// Sync append so replies always land on disk even if the process is
+// killed. createWriteStream buffers and the buffer doesn't always
+// flush on signal-induced exit.
+function reply(obj: any) {
+  fs.appendFileSync(REPLY_FILE, JSON.stringify(obj) + '\n');
+}
+
+async function main() {
+  const platform = new MatrixPlatform({
+    serverUrl: SERVER_URL,
+    serverName: SERVER_NAME,
+    botSecretKey: BOT_SECRET,
+    botHandle: BOT_HANDLE,
+    registrationToken: REG_TOKEN,
+  });
+  await platform.start();
+  reply({ ok: true, started: true, bot_handle: BOT_HANDLE });
+
+  let currentRoom: string | null = null;
+
+  const rl = readline.createInterface({ input: process.stdin });
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let cmd: any;
+    try {
+      cmd = JSON.parse(trimmed);
+    } catch (e: any) {
+      reply({ err: `bad json: ${e.message}` });
+      continue;
+    }
+    try {
+      switch (cmd.cmd) {
+        case 'create-room': {
+          // MatrixPlatform.createRoom(name, opts) returns PlatformRoom.
+          const room = await platform.createRoom(
+            cmd.name || `repro-${Date.now()}`,
+            {
+              type: 'dm',          // simple direct-style; no space-restricted setup
+              encrypted: true,
+              topic: 'federation repro',
+              invite: cmd.invite || [],
+            }
+          );
+          currentRoom = room.id ?? (room as any).room_id ?? String(room);
+          reply({ ok: true, room_id: currentRoom, room_obj: room });
+          break;
+        }
+        case 'invite': {
+          if (!currentRoom) throw new Error('no current room');
+          await platform.inviteToRoom(currentRoom, cmd.user);
+          reply({ ok: true });
+          break;
+        }
+        case 'send': {
+          if (!currentRoom) throw new Error('no current room');
+          const eid = await platform.sendMessage(currentRoom, cmd.text || '');
+          reply({ ok: true, event_id: eid });
+          break;
+        }
+        case 'rotate': {
+          if (!currentRoom) throw new Error('no current room');
+          const crypto = (platform as any).client?.getCrypto();
+          if (!crypto) throw new Error('no crypto');
+          await crypto.forceDiscardSession(currentRoom);
+          reply({ ok: true, rotated: currentRoom });
+          break;
+        }
+        case 'exit':
+          reply({ ok: true, exiting: true });
+          await platform.stop();
+          process.exit(0);
+        default:
+          reply({ err: `unknown cmd: ${cmd.cmd}` });
+      }
+    } catch (e: any) {
+      reply({ err: String(e.message || e) });
+    }
+  }
+}
+
+main().catch((e: any) => {
+  reply({ err: `fatal: ${e.message || e}` });
+  process.exit(1);
+});

--- a/tests/federation-repro/repro/mitm.js
+++ b/tests/federation-repro/repro/mitm.js
@@ -42,28 +42,43 @@ const server = https.createServer({
     let outBody = body;
     let droppedTypes = [];
 
+    // Helper: pull out every "type" claim an EDU makes — outer edu_type,
+    // content.type (m.direct_to_device case where type is on content),
+    // and any inner message types in content.messages.
+    function eduTypes(edu) {
+      const types = new Set();
+      if (edu.edu_type) types.add(edu.edu_type);
+      if (edu.type) types.add(edu.type);
+      if (edu.content?.type) types.add(edu.content.type);
+      if (edu.content?.messages) {
+        for (const u of Object.values(edu.content.messages)) {
+          for (const m of Object.values(u || {})) {
+            if (m?.type) types.add(m.type);
+          }
+        }
+      }
+      return [...types];
+    }
+
+    if (isFederationSend && body.length > 0 && process.env.MITM_LOG_BODIES === '1') {
+      try {
+        const parsed = JSON.parse(body.toString());
+        const eduSummary = (parsed.edus || []).map((e) => eduTypes(e).join('|') || '?');
+        log({ event: 'send_body', url: req.url, edus: eduSummary, n_pdus: (parsed.pdus || []).length });
+      } catch (_) {}
+    }
+
     if (isFederationSend && DROP_TYPES.length > 0 && body.length > 0) {
       try {
         const parsed = JSON.parse(body.toString());
         if (Array.isArray(parsed.edus)) {
           const before = parsed.edus.length;
           parsed.edus = parsed.edus.filter((edu) => {
-            const t = edu.edu_type || edu.type;
-            if (DROP_TYPES.includes(t)) {
-              droppedTypes.push(t);
+            const types = eduTypes(edu);
+            const matches = types.filter(t => DROP_TYPES.includes(t));
+            if (matches.length > 0) {
+              droppedTypes.push(...matches);
               return false;
-            }
-            // m.direct_to_device wraps inner messages of various types.
-            // Drop the entire EDU if any inner message matches.
-            if (edu.edu_type === 'm.direct_to_device' && edu.content && edu.content.messages) {
-              for (const userMessages of Object.values(edu.content.messages)) {
-                for (const msg of Object.values(userMessages || {})) {
-                  if (msg && DROP_TYPES.includes(msg.type)) {
-                    droppedTypes.push(`(direct_to_device:${msg.type})`);
-                    return false;
-                  }
-                }
-              }
             }
             return true;
           });

--- a/tests/federation-repro/repro/mitm.js
+++ b/tests/federation-repro/repro/mitm.js
@@ -1,0 +1,105 @@
+// Federation MITM. Sits in front of hs-b on the docker bridge:
+//
+//   hs-a-core  →  MITM (alias `hs-b`, TLS :8448)  →  hs-b-real (the real nginx)
+//
+// Default: pass-through. When MITM_DROP_TYPES is set (comma-separated),
+// POST /_matrix/federation/v1/send/<txnId> requests have any matching
+// to-device EDU types stripped from the JSON body before forwarding.
+//
+// Plain Node JS so it runs in node:24-alpine with no install dance.
+
+const https = require('node:https');
+const fs = require('node:fs');
+
+const LISTEN_PORT   = Number(process.env.MITM_LISTEN_PORT || 8448);
+const UPSTREAM_HOST = process.env.MITM_UPSTREAM_HOST || 'hs-b-real';
+const UPSTREAM_PORT = Number(process.env.MITM_UPSTREAM_PORT || 8448);
+const TLS_CERT      = process.env.MITM_TLS_CERT || '/certs/hs-b.crt';
+const TLS_KEY       = process.env.MITM_TLS_KEY  || '/certs/hs-b.key';
+const UPSTREAM_CA   = process.env.MITM_UPSTREAM_CA || '/certs/ca.pem';
+const DROP_TYPES    = (process.env.MITM_DROP_TYPES || '').split(',').filter(Boolean);
+const LOG_FILE      = process.env.MITM_LOG_FILE || '';
+
+function log(obj) {
+  const line = JSON.stringify({ ts: Date.now(), ...obj });
+  console.log(line);
+  if (LOG_FILE) {
+    try { fs.appendFileSync(LOG_FILE, line + '\n'); } catch (_) {}
+  }
+}
+
+const upstreamCa = fs.readFileSync(UPSTREAM_CA);
+
+const server = https.createServer({
+  cert: fs.readFileSync(TLS_CERT),
+  key:  fs.readFileSync(TLS_KEY),
+}, (req, res) => {
+  const chunks = [];
+  req.on('data', c => chunks.push(c));
+  req.on('end', () => {
+    const body = Buffer.concat(chunks);
+    const isFederationSend = req.url && /^\/_matrix\/federation\/v1\/send\//.test(req.url);
+    let outBody = body;
+    let droppedTypes = [];
+
+    if (isFederationSend && DROP_TYPES.length > 0 && body.length > 0) {
+      try {
+        const parsed = JSON.parse(body.toString());
+        if (Array.isArray(parsed.edus)) {
+          const before = parsed.edus.length;
+          parsed.edus = parsed.edus.filter((edu) => {
+            const t = edu.edu_type || edu.type;
+            if (DROP_TYPES.includes(t)) {
+              droppedTypes.push(t);
+              return false;
+            }
+            // m.direct_to_device wraps inner messages of various types.
+            // Drop the entire EDU if any inner message matches.
+            if (edu.edu_type === 'm.direct_to_device' && edu.content && edu.content.messages) {
+              for (const userMessages of Object.values(edu.content.messages)) {
+                for (const msg of Object.values(userMessages || {})) {
+                  if (msg && DROP_TYPES.includes(msg.type)) {
+                    droppedTypes.push(`(direct_to_device:${msg.type})`);
+                    return false;
+                  }
+                }
+              }
+            }
+            return true;
+          });
+          if (before !== parsed.edus.length) {
+            outBody = Buffer.from(JSON.stringify(parsed));
+            log({ event: 'mitm_drop', url: req.url, dropped: droppedTypes });
+          }
+        }
+      } catch (e) {
+        log({ event: 'mitm_parse_err', url: req.url, err: String(e.message || e) });
+      }
+    }
+
+    const opts = {
+      host: UPSTREAM_HOST,
+      port: UPSTREAM_PORT,
+      method: req.method,
+      path: req.url,
+      headers: { ...req.headers, host: `${UPSTREAM_HOST}:${UPSTREAM_PORT}`, 'content-length': String(outBody.length) },
+      ca: upstreamCa,
+      // hs-b-real serves the cert for "hs-b". TLS handshake checks SAN.
+      servername: 'hs-b',
+    };
+    const upstream = https.request(opts, upRes => {
+      res.writeHead(upRes.statusCode || 502, upRes.headers);
+      upRes.pipe(res);
+    });
+    upstream.on('error', (err) => {
+      log({ event: 'upstream_err', url: req.url, err: String(err.message || err) });
+      if (!res.headersSent) res.writeHead(502, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ errcode: 'M_UNKNOWN', error: `mitm: ${err.message}` }));
+    });
+    upstream.end(outBody);
+  });
+});
+
+server.listen(LISTEN_PORT, '0.0.0.0', () => {
+  log({ event: 'listening', port: LISTEN_PORT, drop_types: DROP_TYPES, upstream: `${UPSTREAM_HOST}:${UPSTREAM_PORT}` });
+});

--- a/tests/federation-repro/repro/mitm.ts
+++ b/tests/federation-repro/repro/mitm.ts
@@ -1,0 +1,115 @@
+/**
+ * Federation MITM. Sits in front of hs-b on the docker bridge:
+ *
+ *   hs-a-core  →  MITM (alias `hs-b`, listens TLS :8448)  →  hs-b-real (the real nginx, was `hs-b`)
+ *
+ * Default behavior: pass-through. When MITM_DROP_TYPES is set (comma-
+ * separated), POST /_matrix/federation/v1/send/<txnId> requests have any
+ * matching to-device EDU types stripped from the JSON body before
+ * forwarding. Other parts of the EDU/PDU array pass through untouched.
+ *
+ * Env:
+ *   MITM_LISTEN_PORT       default 8448
+ *   MITM_UPSTREAM_HOST     default hs-b-real
+ *   MITM_UPSTREAM_PORT     default 8448
+ *   MITM_TLS_CERT          default /certs/hs-b.crt
+ *   MITM_TLS_KEY           default /certs/hs-b.key
+ *   MITM_UPSTREAM_CA       default /certs/ca.pem
+ *   MITM_DROP_TYPES        e.g. "m.room_key,m.room_key.withheld"
+ *   MITM_LOG_FILE          path to log dropped/forwarded events (one JSON line each)
+ */
+import * as https from 'node:https';
+import * as fs from 'node:fs';
+import { Buffer } from 'node:buffer';
+
+const LISTEN_PORT   = Number(process.env.MITM_LISTEN_PORT || 8448);
+const UPSTREAM_HOST = process.env.MITM_UPSTREAM_HOST || 'hs-b-real';
+const UPSTREAM_PORT = Number(process.env.MITM_UPSTREAM_PORT || 8448);
+const TLS_CERT      = process.env.MITM_TLS_CERT || '/certs/hs-b.crt';
+const TLS_KEY       = process.env.MITM_TLS_KEY  || '/certs/hs-b.key';
+const UPSTREAM_CA   = process.env.MITM_UPSTREAM_CA || '/certs/ca.pem';
+const DROP_TYPES    = (process.env.MITM_DROP_TYPES || '').split(',').filter(Boolean);
+const LOG_FILE      = process.env.MITM_LOG_FILE || '';
+
+function log(obj: any) {
+  const line = JSON.stringify({ ts: Date.now(), ...obj });
+  console.log(line);
+  if (LOG_FILE) fs.appendFileSync(LOG_FILE, line + '\n');
+}
+
+const upstreamCa = fs.readFileSync(UPSTREAM_CA);
+
+const server = https.createServer({
+  cert: fs.readFileSync(TLS_CERT),
+  key:  fs.readFileSync(TLS_KEY),
+}, (req, res) => {
+  const chunks: Buffer[] = [];
+  req.on('data', c => chunks.push(c));
+  req.on('end', () => {
+    const body = Buffer.concat(chunks);
+    const isFederationSend = req.url && /^\/_matrix\/federation\/v1\/send\//.test(req.url);
+    let outBody = body;
+    let droppedTypes: string[] = [];
+
+    if (isFederationSend && DROP_TYPES.length > 0 && body.length > 0) {
+      try {
+        const parsed = JSON.parse(body.toString());
+        if (Array.isArray(parsed.edus)) {
+          const before = parsed.edus.length;
+          parsed.edus = parsed.edus.filter((edu: any) => {
+            if (DROP_TYPES.includes(edu.edu_type) || DROP_TYPES.includes(edu.type)) {
+              droppedTypes.push(edu.edu_type || edu.type);
+              return false;
+            }
+            // Special case: m.direct_to_device EDU wraps inner messages of various types.
+            // Drop the entire EDU if any of its inner messages match.
+            if (edu.edu_type === 'm.direct_to_device' && edu.content?.messages) {
+              for (const userMessages of Object.values(edu.content.messages) as any[]) {
+                for (const msg of Object.values(userMessages || {}) as any[]) {
+                  if (msg && DROP_TYPES.includes(msg.type)) {
+                    droppedTypes.push(`(direct_to_device:${msg.type})`);
+                    return false;
+                  }
+                }
+              }
+            }
+            return true;
+          });
+          if (before !== parsed.edus.length) {
+            outBody = Buffer.from(JSON.stringify(parsed));
+            log({ event: 'mitm_drop', url: req.url, dropped: droppedTypes });
+          }
+        }
+      } catch (e: any) {
+        log({ event: 'mitm_parse_err', url: req.url, err: String(e.message || e) });
+      }
+    }
+
+    const opts = {
+      host: UPSTREAM_HOST,
+      port: UPSTREAM_PORT,
+      method: req.method,
+      path: req.url,
+      headers: { ...req.headers, host: `${UPSTREAM_HOST}:${UPSTREAM_PORT}`, 'content-length': String(outBody.length) },
+      ca: upstreamCa,
+      // hs-b-real serves the cert for "hs-b" (its alias when it was the only proxy);
+      // even though we connect to the upstream by a different alias,
+      // setting servername preserves the TLS handshake correctness.
+      servername: 'hs-b',
+    };
+    const upstream = https.request(opts, upRes => {
+      res.writeHead(upRes.statusCode || 502, upRes.headers);
+      upRes.pipe(res);
+    });
+    upstream.on('error', (err: any) => {
+      log({ event: 'upstream_err', url: req.url, err: String(err.message || err) });
+      if (!res.headersSent) res.writeHead(502, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ errcode: 'M_UNKNOWN', error: `mitm: ${err.message}` }));
+    });
+    upstream.end(outBody);
+  });
+});
+
+server.listen(LISTEN_PORT, '0.0.0.0', () => {
+  log({ event: 'listening', port: LISTEN_PORT, drop_types: DROP_TYPES, upstream: `${UPSTREAM_HOST}:${UPSTREAM_PORT}` });
+});

--- a/tests/federation-repro/repro/user.py
+++ b/tests/federation-repro/repro/user.py
@@ -1,0 +1,126 @@
+"""
+Repro user — registers/logs in on hs-b, accepts pending invites, syncs
+continuously, and emits one JSON line per decrypted-or-failed encrypted
+event seen.
+
+Stdout protocol:
+  {"event": "ready", "user_id": "..."}
+  {"event": "invite", "room_id": "..."}            # pending invite seen
+  {"event": "joined", "room_id": "..."}            # joined a room
+  {"event": "decrypt_ok", "room_id": "...", "body": "..."}
+  {"event": "decrypt_fail", "room_id": "...", "reason": "..."}
+  {"event": "exit"}
+
+Stdin protocol (one JSON object per line, optional driver control):
+  {"cmd": "join", "room_id": "..."}                 # join a specific room (e.g. via invite alias)
+  {"cmd": "exit"}
+
+Run: pip install matrix-nio[e2e]; python user.py
+Env:
+  FED_REPRO_HS_B_URL   default http://localhost:8002
+  FED_REPRO_USER       default repro-user-<pid>
+  FED_REPRO_USER_PASS  default same-as-USER
+  FED_REPRO_TOKEN      default fedrepro
+"""
+import asyncio, json, os, sys
+from nio import (
+    AsyncClient, AsyncClientConfig, LoginResponse, RoomMessageText,
+    InviteMemberEvent, MegolmEvent, RegisterResponse,
+)
+import aiohttp
+
+HS_URL  = os.environ.get("FED_REPRO_HS_B_URL", "http://localhost:8002")
+USER    = os.environ.get("FED_REPRO_USER",    f"repro-user-{os.getpid()}")
+PASS    = os.environ.get("FED_REPRO_USER_PASS", USER)
+TOKEN   = os.environ.get("FED_REPRO_TOKEN",   "fedrepro")
+STORE   = os.environ.get("FED_REPRO_USER_STORE", f"/tmp/fed-repro-user-{os.getpid()}")
+
+
+def emit(obj):
+    print(json.dumps(obj), flush=True)
+
+
+async def register_or_login(hs_url: str, user: str, password: str, token: str) -> str | None:
+    """Returns access_token via UI-auth registration with token, or login if user exists."""
+    async with aiohttp.ClientSession() as s:
+        # Try login first
+        async with s.post(f"{hs_url}/_matrix/client/v3/login", json={
+            "type": "m.login.password",
+            "identifier": {"type": "m.id.user", "user": user},
+            "password": password,
+        }) as r:
+            if r.status == 200:
+                return user  # login worked, fall through to nio login
+        # Register via UIA registration_token
+        async with s.post(f"{hs_url}/_matrix/client/v3/register", json={
+            "username": user, "password": password,
+        }) as r:
+            init = await r.json()
+        async with s.post(f"{hs_url}/_matrix/client/v3/register", json={
+            "username": user, "password": password,
+            "auth": {
+                "type": "m.login.registration_token",
+                "token": token,
+                "session": init.get("session"),
+            },
+        }) as r:
+            data = await r.json()
+            if r.status != 200:
+                emit({"event": "register_fail", "status": r.status, "body": data})
+                return None
+        return user
+
+
+async def main():
+    os.makedirs(STORE, exist_ok=True)
+    await register_or_login(HS_URL, USER, PASS, TOKEN)
+
+    config = AsyncClientConfig(
+        store_sync_tokens=True,
+        encryption_enabled=True,
+    )
+    client = AsyncClient(HS_URL, f"@{USER}:hs-b", store_path=STORE, config=config)
+    resp = await client.login(PASS, device_name="fed-repro-user")
+    if not isinstance(resp, LoginResponse):
+        emit({"event": "login_fail", "resp": str(resp)})
+        return
+    emit({"event": "ready", "user_id": resp.user_id, "device_id": resp.device_id})
+
+    if client.should_upload_keys:
+        await client.keys_upload()
+
+    async def on_invite(room, event):
+        emit({"event": "invite", "room_id": room.room_id, "from": event.sender})
+        # Auto-accept
+        try:
+            await client.join(room.room_id)
+            emit({"event": "joined", "room_id": room.room_id})
+        except Exception as e:
+            emit({"event": "join_fail", "room_id": room.room_id, "err": str(e)})
+
+    async def on_text(room, event):
+        emit({"event": "decrypt_ok",
+              "room_id": room.room_id,
+              "body": event.body,
+              "sender": event.sender,
+              "event_id": event.event_id})
+
+    async def on_megolm_undecryptable(room, event):
+        emit({"event": "decrypt_fail",
+              "room_id": room.room_id,
+              "event_id": event.event_id,
+              "sender": event.sender,
+              "reason": "megolm — no session key"})
+
+    client.add_event_callback(on_text, RoomMessageText)
+    client.add_event_callback(on_megolm_undecryptable, MegolmEvent)
+    client.add_event_callback(on_invite, InviteMemberEvent)
+
+    await client.sync_forever(timeout=10000, full_state=True)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        emit({"event": "exit"})

--- a/tests/federation-repro/repro/user.py
+++ b/tests/federation-repro/repro/user.py
@@ -79,7 +79,13 @@ async def main():
         store_sync_tokens=True,
         encryption_enabled=True,
     )
-    client = AsyncClient(HS_URL, f"@{USER}:hs-b", store_path=STORE, config=config)
+    # Stable device_id across runs so the bot's cached device list
+    # for this user stays valid. Without this, every test run gets a
+    # fresh device_id and the bot's m.room_key sharing addresses the
+    # OLD device, masking the actual rotation behavior under test.
+    DEVICE_ID = "fed-repro-user-dev"
+    client = AsyncClient(HS_URL, f"@{USER}:hs-b", device_id=DEVICE_ID,
+                         store_path=STORE, config=config)
     resp = await client.login(PASS, device_name="fed-repro-user")
     if not isinstance(resp, LoginResponse):
         emit({"event": "login_fail", "resp": str(resp)})

--- a/tests/federation-repro/scripts/extract-bootstrap-tokens.sh
+++ b/tests/federation-repro/scripts/extract-bootstrap-tokens.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Continuwuity 0.5.x prints a one-time bootstrap registration token on
+# first boot and refuses to honor CONDUWUIT_REGISTRATION_TOKEN until at
+# least one account is created using that bootstrap token. Extract both
+# HSes' tokens from compose logs so the runner can pre-register the
+# bot+user accounts.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Wait for both HSes to print their welcome banner (token included).
+for hs in hs-a-core hs-b-core; do
+  for i in $(seq 1 60); do
+    if docker compose logs "$hs" 2>/dev/null | grep -q 'registration token'; then break; fi
+    sleep 1
+  done
+done
+
+extract() {
+  docker compose logs "$1" 2>/dev/null \
+    | sed -E 's/\x1b\[[0-9;]*m//g' \
+    | grep -oE 'registration token [A-Za-z0-9]+' \
+    | head -n1 \
+    | awk '{print $NF}'
+}
+
+A=$(extract hs-a-core)
+B=$(extract hs-b-core)
+[ -n "$A" ] || { echo "[bootstrap] hs-a-core token not found in logs" >&2; exit 1; }
+[ -n "$B" ] || { echo "[bootstrap] hs-b-core token not found in logs" >&2; exit 1; }
+
+cat <<EOF
+HS_A_BOOTSTRAP_TOKEN=$A
+HS_B_BOOTSTRAP_TOKEN=$B
+EOF

--- a/tests/federation-repro/scripts/gen-certs.sh
+++ b/tests/federation-repro/scripts/gen-certs.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Generate a shared CA + per-homeserver TLS certs so two continuwuity
+# instances can federate over HTTPS on a docker bridge network. Both HSes
+# trust the same CA, so federation handshakes succeed without going
+# through Let's Encrypt or a public DNS chain.
+set -euo pipefail
+cd "$(dirname "$0")/../certs"
+
+# Idempotent: only regenerate if missing.
+[ -f ca.pem ] && [ -f hs-a.crt ] && [ -f hs-b.crt ] && {
+  echo "[gen-certs] already present, skipping"
+  exit 0
+}
+
+echo "[gen-certs] creating CA"
+openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+  -keyout ca.key -out ca.pem -subj "/CN=fed-repro-ca"
+
+for h in hs-a hs-b; do
+  echo "[gen-certs] $h"
+  openssl req -newkey rsa:2048 -nodes \
+    -keyout "$h.key" -out "$h.csr" -subj "/CN=$h"
+  cat > "$h.cnf" <<EOF
+subjectAltName = DNS:$h, DNS:$h.fedrepro.test, DNS:localhost, IP:127.0.0.1
+extendedKeyUsage = serverAuth
+EOF
+  openssl x509 -req -in "$h.csr" \
+    -CA ca.pem -CAkey ca.key -CAcreateserial \
+    -out "$h.crt" -days 365 \
+    -extfile "$h.cnf"
+  rm "$h.csr" "$h.cnf"
+done
+rm -f ca.srl
+
+echo "[gen-certs] done"
+ls -la

--- a/tests/federation-repro/scripts/nginx-hs-a.conf
+++ b/tests/federation-repro/scripts/nginx-hs-a.conf
@@ -1,0 +1,31 @@
+# Federation TLS proxy for hs-a. Listens on :8448 (HTTPS), forwards to
+# hs-a-core:6167 (HTTP). Also serves :443 for client API + .well-known
+# so the federation tester / peers can resolve us cleanly.
+server {
+    listen 8448 ssl;
+    server_name hs-a _;
+    ssl_certificate     /certs/hs-a.crt;
+    ssl_certificate_key /certs/hs-a.key;
+
+    location /_matrix/ {
+        proxy_pass http://hs-a-core:6167;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_read_timeout 300s;
+    }
+
+    location /.well-known/matrix/server {
+        return 200 '{"m.server":"hs-a:8448"}';
+        add_header Content-Type application/json;
+    }
+}
+
+server {
+    listen 80;
+    server_name hs-a _;
+    location /.well-known/matrix/server {
+        return 200 '{"m.server":"hs-a:8448"}';
+        add_header Content-Type application/json;
+    }
+    location / { return 404; }
+}

--- a/tests/federation-repro/scripts/nginx-hs-b.conf
+++ b/tests/federation-repro/scripts/nginx-hs-b.conf
@@ -1,0 +1,31 @@
+# Federation TLS proxy for hs-b. Listens on :8448 (HTTPS), forwards to
+# hs-b-core:6167 (HTTP). Also serves :443 for client API + .well-known
+# so the federation tester / peers can resolve us cleanly.
+server {
+    listen 8448 ssl;
+    server_name hs-b _;
+    ssl_certificate     /certs/hs-b.crt;
+    ssl_certificate_key /certs/hs-b.key;
+
+    location /_matrix/ {
+        proxy_pass http://hs-b-core:6167;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_read_timeout 300s;
+    }
+
+    location /.well-known/matrix/server {
+        return 200 '{"m.server":"hs-b:8448"}';
+        add_header Content-Type application/json;
+    }
+}
+
+server {
+    listen 80;
+    server_name hs-b _;
+    location /.well-known/matrix/server {
+        return 200 '{"m.server":"hs-b:8448"}';
+        add_header Content-Type application/json;
+    }
+    location / { return 404; }
+}

--- a/tests/federation-repro/scripts/run-baseline.sh
+++ b/tests/federation-repro/scripts/run-baseline.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Phase 2: federated encrypted-room baseline.
+#
+# Steps:
+#   1. Bring up hs-a, hs-b and their TLS proxies (assumed already up)
+#   2. Extract bootstrap tokens, register bot on hs-a + user on hs-b
+#   3. Spawn bot.ts (matrix-js-sdk + rust crypto), spawn user.py (matrix-nio)
+#   4. Bot creates encrypted room, invites @user:hs-b
+#   5. User auto-accepts invite
+#   6. Bot sends "baseline ping"
+#   7. Assert user.py emits decrypt_ok with body "baseline ping"
+#   8. Tear down processes
+#
+# Exits 0 on baseline success.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+REPRO_DIR="$(pwd)"
+SERVER_DIR="$(cd ../../server && pwd)"
+
+: "${BOT_HANDLE:=repro-bot}"
+: "${USER_HANDLE:=repro-user}"
+: "${USER_PASS:=repro-user-pw}"
+
+echo "[run-baseline] extracting bootstrap tokens"
+eval "$(bash scripts/extract-bootstrap-tokens.sh)"
+echo "  hs-a bootstrap: $HS_A_BOOTSTRAP_TOKEN"
+echo "  hs-b bootstrap: $HS_B_BOOTSTRAP_TOKEN"
+
+# Derive the bot password the same way MatrixPlatform.start() does, so its
+# subsequent login succeeds.
+BOT_SECRET="repro-bot-secret"
+BOT_PASS=$(node -e "
+const c = require('crypto');
+process.stdout.write(c.createHmac('sha256','$BOT_SECRET').update('matrix:hs-a').digest('base64url'));
+")
+
+register_if_needed() {
+  local label="$1" hs="$2" user="$3" password="$4" token="$5"
+  local login=$(curl -sS -X POST "$hs/_matrix/client/v3/login" \
+    -H 'Content-Type: application/json' \
+    -d "{\"type\":\"m.login.password\",\"identifier\":{\"type\":\"m.id.user\",\"user\":\"$user\"},\"password\":\"$password\"}")
+  if echo "$login" | grep -q '"access_token"'; then
+    echo "  $label: $user already exists (login OK)"
+    return 0
+  fi
+  local init=$(curl -sS -X POST "$hs/_matrix/client/v3/register" \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$user\",\"password\":\"$password\"}")
+  local session=$(echo "$init" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("session",""))')
+  local resp=$(curl -sS -X POST "$hs/_matrix/client/v3/register" \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$user\",\"password\":\"$password\",\"auth\":{\"type\":\"m.login.registration_token\",\"token\":\"$token\",\"session\":\"$session\"}}")
+  if echo "$resp" | grep -q '"user_id"'; then
+    echo "  $label: $user registered"
+    return 0
+  fi
+  if echo "$resp" | grep -q M_USER_IN_USE; then
+    echo "  $label: $user already exists (M_USER_IN_USE)"
+    return 0
+  fi
+  echo "[run-baseline] $label register failed: $resp" >&2
+  return 1
+}
+
+register_if_needed "bot"  http://localhost:8001 "$BOT_HANDLE"  "$BOT_PASS"  "$HS_A_BOOTSTRAP_TOKEN" || exit 1
+register_if_needed "user" http://localhost:8002 "$USER_HANDLE" "$USER_PASS" "$HS_B_BOOTSTRAP_TOKEN" || exit 1
+
+# Output FIFOs for sync between the two scripts.
+TMP=$(mktemp -d)
+cleanup() {
+  echo
+  echo "=== bot.err (tail) ==="; tail -40 "$TMP/bot.err" 2>/dev/null || true
+  echo "=== bot.out (tail) ==="; tail -20 "$TMP/bot.out" 2>/dev/null || true
+  echo "=== user.err (tail) ==="; tail -40 "$TMP/user.err" 2>/dev/null || true
+  echo "=== user.out (tail) ==="; tail -20 "$TMP/user.out" 2>/dev/null || true
+  rm -rf "$TMP"
+  jobs -p | xargs -r kill 2>/dev/null || true
+}
+trap cleanup EXIT
+
+mkfifo "$TMP/bot.in"
+touch "$TMP/bot.replies" "$TMP/user.out"
+
+echo "[run-baseline] starting user.py (background)"
+FED_REPRO_HS_B_URL=http://localhost:8002 \
+FED_REPRO_USER="$USER_HANDLE" \
+FED_REPRO_USER_PASS="$USER_PASS" \
+FED_REPRO_TOKEN="$HS_B_BOOTSTRAP_TOKEN" \
+FED_REPRO_USER_STORE="$TMP/user-store" \
+python3 repro/user.py > "$TMP/user.out" 2>"$TMP/user.err" &
+USER_PID=$!
+
+echo "[run-baseline] starting bot.ts (background)"
+(
+  cd "$SERVER_DIR"
+  FED_REPRO_HS_A_URL=http://localhost:8001 \
+  FED_REPRO_HS_A_NAME=hs-a \
+  FED_REPRO_TOKEN="$HS_A_BOOTSTRAP_TOKEN" \
+  FED_REPRO_BOT_HANDLE="$BOT_HANDLE" \
+  FED_REPRO_BOT_SECRET="$BOT_SECRET" \
+  FED_REPRO_BOT_REPLY_FILE="$TMP/bot.replies" \
+  MATRIX_CRYPTO_SNAPSHOT_PATH="$TMP/bot-snap.json" \
+  MATRIX_CREDS_PATH="$TMP/bot-creds.json" \
+  npx tsx "$REPRO_DIR/repro/bot.ts" < "$TMP/bot.in" > "$TMP/bot.out" 2>"$TMP/bot.err"
+) &
+BOT_PID=$!
+
+# Open the bot's stdin FIFO for write
+exec 7> "$TMP/bot.in"
+
+read_until() {
+  local file="$1" pattern="$2" timeout="${3:-30}"
+  local start=$(date +%s)
+  while true; do
+    if grep -q "$pattern" "$file" 2>/dev/null; then return 0; fi
+    if [ $(( $(date +%s) - start )) -ge "$timeout" ]; then return 1; fi
+    sleep 0.5
+  done
+}
+
+echo "[run-baseline] waiting for bot to start..."
+read_until "$TMP/bot.replies" '"started":true' 60 || { echo "bot failed to start"; cat "$TMP/bot.err"; exit 1; }
+
+echo "[run-baseline] waiting for user.py ready..."
+read_until "$TMP/user.out" '"event": "ready"' 30 || { echo "user failed to ready"; cat "$TMP/user.err"; exit 1; }
+
+echo "[run-baseline] bot creates encrypted room"
+echo '{"cmd":"create-room","name":"phase2-baseline"}' >&7
+read_until "$TMP/bot.replies" '"room_id"' 30 || { echo "bot create-room timeout"; exit 1; }
+ROOM_ID=$(grep -o '"room_id":"[^"]*"' "$TMP/bot.replies" | tail -1 | cut -d'"' -f4)
+echo "  room: $ROOM_ID"
+
+echo "[run-baseline] bot invites @${USER_HANDLE}:hs-b"
+echo "{\"cmd\":\"invite\",\"user\":\"@${USER_HANDLE}:hs-b\"}" >&7
+sleep 2  # give federation a moment to deliver the invite
+
+echo "[run-baseline] waiting for user to auto-accept and join"
+read_until "$TMP/user.out" '"event": "joined"' 30 || { echo "user did not join"; cat "$TMP/user.err"; exit 1; }
+
+echo "[run-baseline] bot sends 'baseline ping'"
+echo '{"cmd":"send","text":"baseline ping"}' >&7
+sleep 1
+
+echo "[run-baseline] waiting for user to receive + decrypt"
+read_until "$TMP/user.out" 'decrypt_ok.*baseline ping' 30 \
+  || { echo "user did not decrypt 'baseline ping'"; tail -30 "$TMP/user.out"; exit 1; }
+
+echo
+echo "[run-baseline] ✅ BASELINE PASSED — federated encrypted round-trip works"
+echo
+echo '{"cmd":"exit"}' >&7
+wait $BOT_PID 2>/dev/null || true
+kill $USER_PID 2>/dev/null || true
+wait 2>/dev/null || true

--- a/tests/federation-repro/scripts/run-bug.sh
+++ b/tests/federation-repro/scripts/run-bug.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# Phase 3 + 4: reproduce the production bug + verify the fix.
+#
+# Scenario:
+#   1. Baseline: bot sends "baseline-ping", user decrypts ok.
+#   2. Arm MITM (drop m.room_key from federation /send).
+#   3. forceDiscardSession on bot, send "stuck-1": fresh outbound megolm
+#      session is created, its m.room_key to-device EDU is dropped by
+#      the MITM, m.room.encrypted reaches user but they have no key.
+#   4. Send "stuck-2" reusing the same broken session — also undecryptable.
+#   5. Disarm MITM (federation now healthy).
+#   6. Send "post-restore" reusing the broken session — STILL
+#      undecryptable, because matrix-rust-sdk doesn't auto-rotate.
+#      THIS REPRODUCES THE PRODUCTION BUG.
+#   7. Briefly restart hs-a-core to trigger a sync interruption + recovery.
+#   8. Send "after-recovery":
+#      - WITHOUT FIX (MATRIX_DISABLE_MEGOLM_AUTOROTATE=1): same broken
+#        session, still undecryptable.
+#      - WITH FIX: sync-recovery hook fires forceDiscardSession on
+#        reconnect → fresh session → m.room_key delivers cleanly → user
+#        decrypts.
+#
+# Run modes:
+#   bash run-bug.sh                       → with fix (default)
+#   FIX=disabled bash run-bug.sh          → without fix
+#
+# Asserts:
+#   FIX=disabled  exit nonzero unless step 6 stays broken AND step 8 stays broken
+#   FIX=enabled   exit nonzero unless step 6 stays broken AND step 8 RECOVERS
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+REPRO_DIR="$(pwd)"
+SERVER_DIR="$(cd ../../server && pwd)"
+FIX="${FIX:-enabled}"
+
+: "${BOT_HANDLE:=repro-bot}"
+: "${USER_HANDLE:=repro-user}"
+: "${USER_PASS:=repro-user-pw}"
+BOT_SECRET="repro-bot-secret"
+BOT_PASS=$(node -e "
+const c = require('crypto');
+process.stdout.write(c.createHmac('sha256','$BOT_SECRET').update('matrix:hs-a').digest('base64url'));
+")
+
+eval "$(bash scripts/extract-bootstrap-tokens.sh)"
+
+register_if_needed() {
+  local hs="$1" user="$2" password="$3" token="$4"
+  local login=$(curl -sS -X POST "$hs/_matrix/client/v3/login" \
+    -H 'Content-Type: application/json' \
+    -d "{\"type\":\"m.login.password\",\"identifier\":{\"type\":\"m.id.user\",\"user\":\"$user\"},\"password\":\"$password\"}")
+  if echo "$login" | grep -q '"access_token"'; then return 0; fi
+  local init=$(curl -sS -X POST "$hs/_matrix/client/v3/register" \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$user\",\"password\":\"$password\"}")
+  local session=$(echo "$init" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("session",""))')
+  curl -sS -X POST "$hs/_matrix/client/v3/register" \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$user\",\"password\":\"$password\",\"auth\":{\"type\":\"m.login.registration_token\",\"token\":\"$token\",\"session\":\"$session\"}}" \
+    > /dev/null
+}
+
+register_if_needed http://localhost:8001 "$BOT_HANDLE"  "$BOT_PASS"  "$HS_A_BOOTSTRAP_TOKEN"
+register_if_needed http://localhost:8002 "$USER_HANDLE" "$USER_PASS" "$HS_B_BOOTSTRAP_TOKEN"
+
+TMP=$(mktemp -d)
+mkfifo "$TMP/bot.in"
+touch "$TMP/bot.replies"
+
+cleanup() {
+  echo
+  echo "[run-bug] === bot.err (tail) ==="; tail -20 "$TMP/bot.err" 2>/dev/null || true
+  echo "[run-bug] === user.out (tail) ==="; tail -20 "$TMP/user.out" 2>/dev/null || true
+  echo "[run-bug] === bot.replies (tail) ==="; tail -20 "$TMP/bot.replies" 2>/dev/null || true
+  echo "[run-bug] === mitm log (tail) ==="
+  docker compose -f "$REPRO_DIR/docker-compose.yml" logs hs-b 2>/dev/null | grep -i mitm | tail -10 || true
+  rm -rf "$TMP"
+  jobs -p | xargs -r kill 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Helper: arm/disarm the MITM by recreating the hs-b service with a
+# different MITM_DROP_TYPES env. Pass "" to disarm.
+set_mitm_drop() {
+  local types="$1"
+  pushd "$REPRO_DIR" > /dev/null
+  MITM_DROP_TYPES="$types" MITM_LOG_BODIES=1 docker compose up -d --force-recreate hs-b > /dev/null 2>&1
+  popd > /dev/null
+  # Wait for the proxy to be ready
+  for i in $(seq 1 30); do
+    if docker compose -f "$REPRO_DIR/docker-compose.yml" logs hs-b 2>&1 | tail -5 | grep -q '"event":"listening"'; then
+      sleep 1
+      break
+    fi
+    sleep 0.5
+  done
+}
+
+start_user_inline() {
+  # Cannot use $() to capture pid: the captured stdout would block the
+  # caller until the bot's exec replaces stdout. So callers must use
+  # USER_PID=$! immediately after.
+  FED_REPRO_HS_B_URL=http://localhost:8002 \
+  FED_REPRO_USER="$USER_HANDLE" \
+  FED_REPRO_USER_PASS="$USER_PASS" \
+  FED_REPRO_TOKEN="$HS_B_BOOTSTRAP_TOKEN" \
+  FED_REPRO_USER_STORE="$TMP/user-store" \
+  python3 repro/user.py > "$TMP/user.out" 2> "$TMP/user.err" &
+}
+
+start_bot_inline() {
+  (
+    cd "$SERVER_DIR"
+    [ "$FIX" = "disabled" ] && export MATRIX_DISABLE_MEGOLM_AUTOROTATE=1
+    export FED_REPRO_HS_A_URL=http://localhost:8001
+    export FED_REPRO_HS_A_NAME=hs-a
+    export FED_REPRO_TOKEN="$HS_A_BOOTSTRAP_TOKEN"
+    export FED_REPRO_BOT_HANDLE="$BOT_HANDLE"
+    export FED_REPRO_BOT_SECRET="$BOT_SECRET"
+    export FED_REPRO_BOT_REPLY_FILE="$TMP/bot.replies"
+    export MATRIX_CRYPTO_SNAPSHOT_PATH="$TMP/bot-snap.json"
+    export MATRIX_CREDS_PATH="$TMP/bot-creds.json"
+    export MATRIX_MEGOLM_ROTATION_INTERVAL_MS=0
+    exec npx tsx "$REPRO_DIR/repro/bot.ts" < "$TMP/bot.in" > "$TMP/bot.out" 2> "$TMP/bot.err"
+  ) &
+}
+
+read_until() {
+  local file="$1" pattern="$2" timeout="${3:-30}"
+  local start=$(date +%s)
+  while true; do
+    if grep -qE "$pattern" "$file" 2>/dev/null; then return 0; fi
+    if [ $(( $(date +%s) - start )) -ge "$timeout" ]; then return 1; fi
+    sleep 0.5
+  done
+}
+
+count_decrypt_ok_with_body() {
+  grep -c "\"event\": \"decrypt_ok\".*\"body\": \"$1\"" "$TMP/user.out" || true
+}
+
+count_decrypt_fail() {
+  grep -c '"event": "decrypt_fail"' "$TMP/user.out" || true
+}
+
+echo "[run-bug] FIX=$FIX"
+echo "[run-bug] disarming MITM (pass-through)"
+set_mitm_drop ""
+
+start_user_inline; USER_PID=$!
+start_bot_inline;  BOT_PID=$!
+echo "[run-bug] USER_PID=$USER_PID  BOT_PID=$BOT_PID  TMP=$TMP"
+# Open the bot's stdin FIFO so its exec unblocks.
+exec 7> "$TMP/bot.in"
+echo "[run-bug] bot.in fd 7 opened"
+
+read_until "$TMP/bot.replies" '"started":true'      90 || { echo "bot did not start"; exit 1; }
+read_until "$TMP/user.out"    '"event": "ready"'    30 || { echo "user did not ready"; exit 1; }
+
+echo "[run-bug] step 1: baseline"
+echo '{"cmd":"create-room","name":"bug-repro"}' >&7
+read_until "$TMP/bot.replies" '"room_id"' 30 || exit 1
+ROOM_ID=$(grep -o '"room_id":"[^"]*"' "$TMP/bot.replies" | tail -1 | cut -d'"' -f4)
+echo "  room: $ROOM_ID"
+echo "{\"cmd\":\"invite\",\"user\":\"@${USER_HANDLE}:hs-b\"}" >&7
+read_until "$TMP/user.out" '"event": "joined"' 30 || exit 1
+echo '{"cmd":"send","text":"baseline-ping"}' >&7
+read_until "$TMP/user.out" '"body": "baseline-ping"' 30 || { echo "  ✗ baseline failed"; exit 1; }
+echo "  ✓ baseline decrypt_ok"
+
+echo "[run-bug] step 2: arm MITM (drop all to-device — m.room_key is olm-wrapped inside)"
+# matrix-rust-sdk encrypts m.room_key via olm into m.room.encrypted
+# to-device messages, wrapped in m.direct_to_device EDUs. We can't
+# selectively drop "the m.room_key for THIS session" without decrypting
+# olm, so we drop ALL to-device traffic to simulate the production
+# federation-queue-backoff window. matches the matrix.org → mtrx
+# scenario from 2026-05-09 where the per-server queue backed off so
+# hard that everything queued during the window failed to deliver.
+set_mitm_drop "m.direct_to_device"
+
+echo "[run-bug] step 3: bot rotates session, sends stuck-1"
+echo '{"cmd":"rotate"}' >&7
+read_until "$TMP/bot.replies" '"rotated"' 10
+echo '{"cmd":"send","text":"stuck-1"}' >&7
+sleep 8
+STUCK1=$(count_decrypt_ok_with_body "stuck-1")
+if [ "$STUCK1" -eq 0 ]; then
+  echo "  ✓ stuck-1 NOT decrypted (m.room_key was dropped by MITM)"
+else
+  echo "  ✗ stuck-1 was decrypted unexpectedly — MITM may not be filtering"; exit 1
+fi
+
+echo "[run-bug] step 4: send stuck-2 (same broken session)"
+echo '{"cmd":"send","text":"stuck-2"}' >&7
+sleep 4
+STUCK2=$(count_decrypt_ok_with_body "stuck-2")
+if [ "$STUCK2" -eq 0 ]; then echo "  ✓ stuck-2 also undecryptable"; else echo "  ✗ stuck-2 decrypted"; exit 1; fi
+
+if [ "${KEEP_ARMED:-0}" = "1" ]; then
+  echo "[run-bug] step 5: KEEP_ARMED=1 — MITM stays armed (worst-case: federation never recovers for this device)"
+else
+  echo "[run-bug] step 5: disarm MITM (federation healthy again)"
+  set_mitm_drop ""
+fi
+sleep 3
+
+echo "[run-bug] step 6: send post-restore (still using broken session)"
+echo '{"cmd":"send","text":"post-restore"}' >&7
+sleep 6
+POST=$(count_decrypt_ok_with_body "post-restore")
+if [ "$POST" -eq 0 ]; then
+  echo "  ✓ BUG REPRODUCED — post-restore still undecryptable on the broken session"
+else
+  echo "  ✗ post-restore decrypted — bug did not reproduce (matrix-rust-sdk auto-recovered, or test setup wrong)"
+  exit 1
+fi
+
+echo "[run-bug] step 7: simulate sync interruption (restart hs-a-core)"
+docker compose -f "$REPRO_DIR/docker-compose.yml" restart hs-a-core > /dev/null 2>&1
+echo "  hs-a-core restarted; waiting for bot sync to recover..."
+sleep 15
+
+echo "[run-bug] step 8: send after-recovery"
+echo '{"cmd":"send","text":"after-recovery"}' >&7
+sleep 8
+AFTER=$(count_decrypt_ok_with_body "after-recovery")
+
+if [ "$FIX" = "disabled" ]; then
+  if [ "$AFTER" -eq 0 ]; then
+    echo "  ✓ FIX_DISABLED: after-recovery undecryptable (no auto-rotation, same broken session)"
+    echo
+    echo "[run-bug] ✅ WITHOUT FIX: bug confirmed — outbound session stays broken across sync recovery"
+  else
+    echo "  ✗ FIX_DISABLED: after-recovery decrypted unexpectedly (didn't expect recovery without the patch)"
+    exit 1
+  fi
+else
+  if [ "$AFTER" -gt 0 ]; then
+    echo "  ✓ WITH FIX: after-recovery decrypted (sync-recovery hook rotated, fresh session, m.room_key delivered)"
+    echo
+    echo "[run-bug] ✅ WITH FIX: rotation patch unwedges the room on sync recovery"
+  else
+    echo "  ✗ WITH FIX: after-recovery still undecryptable — patch didn't fire or didn't help"
+    exit 1
+  fi
+fi
+
+echo '{"cmd":"exit"}' >&7
+wait $BOT_PID 2>/dev/null || true
+kill $USER_PID 2>/dev/null || true
+wait 2>/dev/null || true

--- a/tests/federation-repro/scripts/run-bug.sh
+++ b/tests/federation-repro/scripts/run-bug.sh
@@ -70,11 +70,22 @@ touch "$TMP/bot.replies"
 
 cleanup() {
   echo
+  # Preserve bot.out for inspection — this captures matrix-js-sdk's
+  # internal log lines, useful for understanding what (if anything)
+  # rust-crypto did during the test (e.g. "Discarded existing group session"
+  # from auto-recovery vs. our patch's "[Matrix] discarded N outbound
+  # megolm session(s)").
+  if [ -f "$TMP/bot.out" ]; then
+    cp "$TMP/bot.out" "/tmp/run-bug-bot-out-${FIX}.log"
+    echo "[run-bug] saved bot.out → /tmp/run-bug-bot-out-${FIX}.log ($(wc -l < $TMP/bot.out) lines)"
+  fi
   echo "[run-bug] === bot.err (tail) ==="; tail -20 "$TMP/bot.err" 2>/dev/null || true
   echo "[run-bug] === user.out (tail) ==="; tail -20 "$TMP/user.out" 2>/dev/null || true
   echo "[run-bug] === bot.replies (tail) ==="; tail -20 "$TMP/bot.replies" 2>/dev/null || true
-  echo "[run-bug] === mitm log (tail) ==="
-  docker compose -f "$REPRO_DIR/docker-compose.yml" logs hs-b 2>/dev/null | grep -i mitm | tail -10 || true
+  echo "[run-bug] === bot.out matches: rotation/session activity ==="
+  grep -E "Discarded existing group session|\[Matrix\] discarded|\[Matrix\] sync recovered|\[Matrix\] megolm auto-rotation" "$TMP/bot.out" 2>/dev/null | tail -20 || true
+  echo "[run-bug] === mitm drops ==="
+  docker compose -f "$REPRO_DIR/docker-compose.yml" logs hs-b 2>/dev/null | grep -i mitm_drop | tail -10 || true
   rm -rf "$TMP"
   jobs -p | xargs -r kill 2>/dev/null || true
 }
@@ -101,11 +112,16 @@ start_user_inline() {
   # Cannot use $() to capture pid: the captured stdout would block the
   # caller until the bot's exec replaces stdout. So callers must use
   # USER_PID=$! immediately after.
+  # Stable user store across runs so the user's device_id stays the
+  # same — otherwise the bot's cached device list goes stale and
+  # m.room_key sharing doesn't include the user's current device.
+  : "${FED_REPRO_USER_STORE_BASE:=/tmp/fed-repro-user-store}"
+  mkdir -p "$FED_REPRO_USER_STORE_BASE"
   FED_REPRO_HS_B_URL=http://localhost:8002 \
   FED_REPRO_USER="$USER_HANDLE" \
   FED_REPRO_USER_PASS="$USER_PASS" \
   FED_REPRO_TOKEN="$HS_B_BOOTSTRAP_TOKEN" \
-  FED_REPRO_USER_STORE="$TMP/user-store" \
+  FED_REPRO_USER_STORE="$FED_REPRO_USER_STORE_BASE" \
   python3 repro/user.py > "$TMP/user.out" 2> "$TMP/user.err" &
 }
 
@@ -121,7 +137,12 @@ start_bot_inline() {
     export FED_REPRO_BOT_REPLY_FILE="$TMP/bot.replies"
     export MATRIX_CRYPTO_SNAPSHOT_PATH="$TMP/bot-snap.json"
     export MATRIX_CREDS_PATH="$TMP/bot-creds.json"
-    export MATRIX_MEGOLM_ROTATION_INTERVAL_MS=0
+    # Compress periodic rotation to 8s so the test can observe the
+    # patch's behavior in seconds, not hours. WITHOUT FIX: this env is
+    # ignored (the patch early-returns); session rotation depends on
+    # other triggers (device-list change, sync error, etc.) that we
+    # specifically avoid in the test below.
+    export MATRIX_MEGOLM_ROTATION_INTERVAL_MS=8000
     exec npx tsx "$REPRO_DIR/repro/bot.ts" < "$TMP/bot.in" > "$TMP/bot.out" 2> "$TMP/bot.err"
   ) &
 }
@@ -216,32 +237,32 @@ else
   exit 1
 fi
 
-echo "[run-bug] step 7: simulate sync interruption (restart hs-a-core)"
-docker compose -f "$REPRO_DIR/docker-compose.yml" restart hs-a-core > /dev/null 2>&1
-echo "  hs-a-core restarted; waiting for bot sync to recover..."
-sleep 15
+echo "[run-bug] step 7: wait 12s — past the bot's periodic rotation interval (8s)"
+echo "  WITHOUT FIX: nothing rotates (matrix-js-sdk has no spontaneous rotate trigger here)"
+echo "  WITH FIX:    periodic timer fires forceDiscardSession()"
+sleep 12
 
-echo "[run-bug] step 8: send after-recovery"
-echo '{"cmd":"send","text":"after-recovery"}' >&7
-sleep 8
-AFTER=$(count_decrypt_ok_with_body "after-recovery")
+echo "[run-bug] step 8: send after-rotation"
+echo '{"cmd":"send","text":"after-rotation"}' >&7
+sleep 6
+AFTER=$(count_decrypt_ok_with_body "after-rotation")
 
 if [ "$FIX" = "disabled" ]; then
   if [ "$AFTER" -eq 0 ]; then
-    echo "  ✓ FIX_DISABLED: after-recovery undecryptable (no auto-rotation, same broken session)"
+    echo "  ✓ FIX_DISABLED: after-rotation undecryptable (no auto-rotation, broken session reused)"
     echo
-    echo "[run-bug] ✅ WITHOUT FIX: bug confirmed — outbound session stays broken across sync recovery"
+    echo "[run-bug] ✅ WITHOUT FIX: bug PERSISTS — outbound session stays broken indefinitely"
   else
-    echo "  ✗ FIX_DISABLED: after-recovery decrypted unexpectedly (didn't expect recovery without the patch)"
+    echo "  ✗ FIX_DISABLED: after-rotation decrypted unexpectedly (matrix-js-sdk auto-recovered without our patch)"
     exit 1
   fi
 else
   if [ "$AFTER" -gt 0 ]; then
-    echo "  ✓ WITH FIX: after-recovery decrypted (sync-recovery hook rotated, fresh session, m.room_key delivered)"
+    echo "  ✓ WITH FIX: after-rotation decrypted (periodic timer rotated session, fresh m.room_key delivered)"
     echo
-    echo "[run-bug] ✅ WITH FIX: rotation patch unwedges the room on sync recovery"
+    echo "[run-bug] ✅ WITH FIX: rotation patch unwedges the room — periodic rotation works"
   else
-    echo "  ✗ WITH FIX: after-recovery still undecryptable — patch didn't fire or didn't help"
+    echo "  ✗ WITH FIX: after-rotation still undecryptable — patch didn't fire or didn't help"
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary
Closes a silent-decrypt-failure mode where a federation hiccup during outbound megolm session creation drops the `m.room_key` to-device EDU, leaving every subsequent message in that session undecryptable for receivers. The protocol-level recovery (`m.room_key_request` → `m.forwarded_room_key`) is gated on cross-signing trust by default in matrix-rust-sdk, and bot-to-user is rarely cross-signed, so the request is silently ignored and the room stays broken until manual intervention.

## What this does
Two mitigations in `MatrixPlatform`:

1. **Sync-recovery hook** — on `ClientEvent.Sync` transition INTO `'SYNCING'` from a non-syncing state (i.e. just reconnected), trigger an immediate `forceDiscardSession()` for all encrypted rooms the bot is in. The next outbound message creates a fresh session whose key distribution rides over now-healthy federation.

2. **Periodic rotation** — `setInterval` (default 4h, configurable via `MATRIX_MEGOLM_ROTATION_INTERVAL_MS`) runs the same rotation. Catches the case where recovery happened mid-session creation and the to-device was lost without a visible reconnect signal.

Old undecryptable messages stay undecryptable; this just unwedges the room going forward.

## Concrete history that motivated this
2026-05-09 incident in `Account-Link/shape-rotator-matrix` — 6+ conduwuit restarts in 5h backed up matrix.org's federation queue and dropped the `m.room_key` to-device for both Router (this bot) and `@claw-teedah-2` (mautrix-python). `@claw-teedah-2` auto-recovered within hours; Router stayed broken (Element showing "Unable to decrypt" on every Router post in `#bot-noise`) and required manual intervention because matrix-rust-sdk does not auto-rotate on connection recovery.

Full incident retro: `docs/incidents/2026-05-09-announce-flood.md` in the shape-rotator-matrix repo.

## Test plan
- [ ] Manual: trigger a brief homeserver outage (or block the bot's connection at the network level), wait for sync to recover, verify a `[Matrix] sync recovered ... rotating megolm sessions` log line and `[Matrix] discarded N outbound megolm session(s)`. Send a fresh message in a room a remote user is in, verify they decrypt it.
- [ ] Verify periodic rotation fires every 4h (or override via env).
- [ ] Existing matrix.test.ts / matrix.integration.test.ts still pass.

## Notes
- This doesn't address the deeper "bots without cross-signing get key-share-denied" issue. A full fix would also relax the room-key-forwarding policy to share with any joined device (mautrix exposes `share_keys_min_trust = UNVERIFIED`); matrix-js-sdk's equivalent on `client.getCrypto()` is less clearly exposed in 41.x and might need lower-level rust-crypto access. Periodic + recovery rotation handles the common case without that.
- Rotation interval choice (4h) is conservative. If the bot is chatty it'll get rotated naturally on matrix-rust-sdk's 100-message threshold first, so the timer is mostly for low-traffic rooms.